### PR TITLE
build: fix GitHub workflow image retagging mechanism

### DIFF
--- a/.github/workflows/api-pr-deployment.yml
+++ b/.github/workflows/api-pr-deployment.yml
@@ -49,7 +49,7 @@ jobs:
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
           file: ${{ env.WORKING_DIRECTORY }}/Dockerfile
           context: ${{ env.WORKING_DIRECTORY }}
           cache-from: type=gha
@@ -65,7 +65,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `🐳 **API Docker Image Built Successfully**\n\nPR Image Tags:\n- \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}\`\n- \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-${{ github.sha }}\`\n\n⏳ Deploying to acceptance environment...`
+              body: `🐳 **API Docker Image Built Successfully**\n\nPR Image Tags:\n- \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}\`\n- \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}\`\n\n⏳ Deploying to acceptance environment...`
             })
 
   deploy-pr:
@@ -94,7 +94,7 @@ jobs:
             az containerapp update \
               -n "$CONTAINER_APP_ACC" \
               -g "$RESOURCE_GROUP" \
-              --image "$REGISTRY/$IMAGE_NAME:pr-${{ github.event.pull_request.number }}-${{ github.sha }}"
+              --image "$REGISTRY/$IMAGE_NAME:pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}"
 
       - name: Start Container App
         uses: azure/CLI@v2
@@ -167,7 +167,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `✅ **API Deployed to Acceptance Environment**\n\n🌐 URL: ${{ steps.get-url.outputs.url }}\n📦 Image: \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-${{ github.sha }}\`\n\nYou can now test this PR in the acceptance environment.`
+              body: `✅ **API Deployed to Acceptance Environment**\n\n🌐 URL: ${{ steps.get-url.outputs.url }}\n📦 Image: \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}\`\n\nYou can now test this PR in the acceptance environment.`
             })
 
   stop-pr:

--- a/.github/workflows/web-pr-deployment.yml
+++ b/.github/workflows/web-pr-deployment.yml
@@ -82,7 +82,7 @@ jobs:
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
           file: ${{ env.WORKING_DIRECTORY }}/Dockerfile
           context: ${{ env.WORKING_DIRECTORY }}
           cache-from: type=gha
@@ -100,7 +100,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `🐳 **Web Docker Image Built Successfully**\n\nPR Image Tags:\n- \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}\`\n- \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-${{ github.sha }}\`\n\n⏳ Deploying to acceptance environment...`
+              body: `🐳 **Web Docker Image Built Successfully**\n\nPR Image Tags:\n- \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}\`\n- \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}\`\n\n⏳ Deploying to acceptance environment...`
             })
 
   deploy-pr:
@@ -129,7 +129,7 @@ jobs:
             az containerapp update \
               -n "$CONTAINER_APP_ACC" \
               -g "$RESOURCE_GROUP" \
-              --image "$REGISTRY/$IMAGE_NAME:pr-${{ github.event.pull_request.number }}-${{ github.sha }}" \
+              --image "$REGISTRY/$IMAGE_NAME:pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}" \
               --set-env-vars \
                 STRAPI_API_URL="$STRAPI_API_URL" \
                 STRAPI_API_SECRET=secretref:strapi-api-secret \
@@ -209,7 +209,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `✅ **Web Deployed to Acceptance Environment**\n\n🌐 URL: ${{ steps.get-url.outputs.url }}\n📦 Image: \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-${{ github.sha }}\`\n🔗 Backend: ${{ env.STRAPI_API_URL }}\n\nYou can now test this PR in the acceptance environment.`
+              body: `✅ **Web Deployed to Acceptance Environment**\n\n🌐 URL: ${{ steps.get-url.outputs.url }}\n📦 Image: \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}\`\n🔗 Backend: ${{ env.STRAPI_API_URL }}\n\nYou can now test this PR in the acceptance environment.`
             })
 
   stop-pr:


### PR DESCRIPTION
The production deployment workflows look for images tagged with pr-{number}-{head_sha} (retrieved from the GitHub API), but PR workflows were tagging with github.sha (the merge commit SHA).

This SHA mismatch caused retagging to always fail, forcing a full rebuild on every PR merge.

Changed PR workflows to use github.event.pull_request.head.sha which matches what the production workflow retrieves from the API.