### PR TITLE
fix(web): Fix deprecated lighten() function in SCSS

### DIFF
--- a/packages/web/src/components/layout/scroll-to-top.scss
+++ b/packages/web/src/components/layout/scroll-to-top.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 @use "../../styles/scss/play14.scss" as *;
 
 .scroll-to-top {
@@ -22,7 +23,7 @@
   z-index: 1000;
 
   &:hover {
-    background-color: darken($orange, 10%);
+    background-color: color.adjust($orange, $lightness: -10%);
     transform: translateY(-3px);
     box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
   }

--- a/packages/web/src/styles/scss/_nav-buttons.scss
+++ b/packages/web/src/styles/scss/_nav-buttons.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 @use "./play14.scss" as *;
 
 @mixin nav-buttons-container {
@@ -32,7 +33,7 @@
   cursor: pointer;
 
   &:hover:not(.disabled) {
-    background-color: lighten($orange, 35%);
+    background-color: color.adjust($orange, $lightness: 35%);
     border-color: $orange;
     color: $orange;
     transform: translateY(-2px);


### PR DESCRIPTION
Use modern sass:color module's color.adjust() function instead of the deprecated global lighten() and darken() functions. This resolves Sass deprecation warnings during builds.