### PR TITLE
fix(api): populate reset-password URL on bootstrap

### DIFF
--- a/packages/api/src/bootstrap/email-templates.ts
+++ b/packages/api/src/bootstrap/email-templates.ts
@@ -38,7 +38,12 @@ export async function bootstrapEmailTemplates(strapi: Core.Strapi): Promise<void
 
   // Fix email_reset_password URL in advanced settings
   const advancedSettings = (await advancedStore.get()) as Record<string, unknown> | null
-  if (advancedSettings) {
+  if (!advancedSettings) {
+    strapi.log.warn(
+      "[Email Templates] Advanced settings not found; reset password URL not configured. " +
+        "This usually self-heals on the next restart once users-permissions initialises core_store."
+    )
+  } else {
     const expectedResetUrl = `${frontendUrl}/auth/reset-password`
     if (advancedSettings.email_reset_password !== expectedResetUrl) {
       advancedSettings.email_reset_password = expectedResetUrl

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,4 +1,5 @@
 import type { Core } from "@strapi/strapi"
+import { bootstrapEmailTemplates } from "./bootstrap/email-templates"
 import { bootstrapLikedItemImages } from "./bootstrap/liked-items"
 import { bootstrapPermissions } from "./bootstrap/permissions"
 
@@ -367,6 +368,9 @@ export default {
 
       // Bootstrap user role permissions
       await bootstrapPermissions(strapi)
+
+      // Bootstrap users-permissions email templates (sender + reset-password URL)
+      await bootstrapEmailTemplates(strapi)
 
       // Bootstrap liked items images (uploads images from data folder if missing)
       await bootstrapLikedItemImages(strapi)


### PR DESCRIPTION
## Summary

- `bootstrapEmailTemplates` (in `packages/api/src/bootstrap/email-templates.ts`) is responsible for writing `email_reset_password = ${FRONTEND_URL}/auth/reset-password` into the `users-permissions` advanced settings, but it was never invoked from `packages/api/src/index.ts`.
- After the move to Clever Cloud, the advanced setting was still `null` in the database, so Strapi rendered `<%= URL %>` as an empty string in the reset-password email — producing links like `?code=…` with no host.
- Wire the bootstrap in alongside the other bootstrap steps so the reset URL is re-derived from `FRONTEND_URL` on every startup.

## Test plan

- [ ] Deploy to staging and trigger a password reset; confirm the email link starts with `https://staging.play14.org/auth/reset-password?code=…`
- [ ] Verify startup logs include `[Email Templates] Updated reset password URL to: …`
- [ ] Confirm production `FRONTEND_URL` env var is set to `https://new.play14.org` before deploying
