### PR TITLE
feat(web): add report-an-issue footer link with GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,68 @@
+name: Bug report
+description: Report a problem with the #play14 website
+title: "[Bug]: "
+labels: ["bug", "from-website"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report an issue! Please fill in as much detail as you can so we can reproduce and fix it.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear and concise description of the bug you encountered.
+      placeholder: When I clicked on…, the page showed…
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      placeholder: I expected the page to…
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this issue?
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: false
+  - type: input
+    id: page-url
+    attributes:
+      label: Page URL
+      description: The URL of the page where the issue occurred.
+      placeholder: https://play14.org/…
+    validations:
+      required: false
+  - type: dropdown
+    id: device
+    attributes:
+      label: Device type
+      options:
+        - Desktop
+        - Tablet
+        - Mobile
+        - Other
+    validations:
+      required: false
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and version
+      placeholder: e.g. Chrome 131, Firefox 133, Safari 18
+    validations:
+      required: false
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Screenshots, console errors, or anything else that may help.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug report
 description: Report a problem with the #play14 website
 title: "[Bug]: "
-labels: ["bug", "from-website"]
+labels: ["bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Contact the #play14 team
+    url: https://play14.org/contact
+    about: For questions about the community, events, or partnerships, please use our contact page.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Contact the #play14 team
     url: https://play14.org/contact

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: Feature request
+description: Suggest a new feature or improvement for #play14
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to propose an improvement. The more context you can share, the easier it is to discuss and prioritise.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: Describe the use case or the friction you're hitting today.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: A clear and concise description of what you'd like to see happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches you've thought about, including their trade-offs.
+    validations:
+      required: false
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Links, screenshots, mock-ups, or anything else that might help the discussion.
+    validations:
+      required: false

--- a/packages/web/messages/de.json
+++ b/packages/web/messages/de.json
@@ -782,7 +782,8 @@
     "ourArticles": "Unsere Artikel",
     "copyright": "© 2014 - {year} <strong>#play14</strong> entwickelt von <author>Cédric Pontet</author>",
     "privacyPolicy": "Datenschutzerklärung",
-    "termsOfService": "Nutzungsbedingungen"
+    "termsOfService": "Nutzungsbedingungen",
+    "reportAnIssue": "Problem melden"
   },
   "metadata": {
     "title": "#play14 - play is the way",

--- a/packages/web/messages/de.json
+++ b/packages/web/messages/de.json
@@ -739,7 +739,8 @@
     "serverUnavailable": "Verbindung zum Server nicht möglich",
     "serverUnavailableDescription": "Der Inhaltsserver ist derzeit nicht verfügbar. Dies bedeutet in der Regel, dass das Backend nicht läuft oder nicht erreichbar ist.",
     "tryAgain": "Erneut versuchen",
-    "reportThisIssue": "Dieses Problem melden"
+    "reportThisIssue": "Dieses Problem melden",
+    "opensInNewTab": "wird in neuem Tab geöffnet"
   },
   "nav": {
     "home": "Startseite",

--- a/packages/web/messages/de.json
+++ b/packages/web/messages/de.json
@@ -738,7 +738,8 @@
     "noResults": "Keine Ergebnisse gefunden",
     "serverUnavailable": "Verbindung zum Server nicht möglich",
     "serverUnavailableDescription": "Der Inhaltsserver ist derzeit nicht verfügbar. Dies bedeutet in der Regel, dass das Backend nicht läuft oder nicht erreichbar ist.",
-    "tryAgain": "Erneut versuchen"
+    "tryAgain": "Erneut versuchen",
+    "reportThisIssue": "Problem melden"
   },
   "nav": {
     "home": "Startseite",

--- a/packages/web/messages/de.json
+++ b/packages/web/messages/de.json
@@ -739,7 +739,7 @@
     "serverUnavailable": "Verbindung zum Server nicht möglich",
     "serverUnavailableDescription": "Der Inhaltsserver ist derzeit nicht verfügbar. Dies bedeutet in der Regel, dass das Backend nicht läuft oder nicht erreichbar ist.",
     "tryAgain": "Erneut versuchen",
-    "reportThisIssue": "Problem melden"
+    "reportThisIssue": "Dieses Problem melden"
   },
   "nav": {
     "home": "Startseite",

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -58,7 +58,8 @@
     "ourArticles": "Our articles",
     "copyright": "© 2014 - {year} <strong>#play14</strong> developed by <author>Cédric Pontet</author>",
     "privacyPolicy": "Privacy policy",
-    "termsOfService": "Terms of service"
+    "termsOfService": "Terms of service",
+    "reportAnIssue": "Report an issue"
   },
   "home": {
     "powerOfPlay": {

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -14,7 +14,8 @@
     "noResults": "No results found",
     "serverUnavailable": "Unable to connect to server",
     "serverUnavailableDescription": "The content server is currently unavailable. This usually means the backend is not running or not reachable.",
-    "tryAgain": "Try again"
+    "tryAgain": "Try again",
+    "reportThisIssue": "Report this issue"
   },
   "nav": {
     "home": "Home",

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -15,7 +15,8 @@
     "serverUnavailable": "Unable to connect to server",
     "serverUnavailableDescription": "The content server is currently unavailable. This usually means the backend is not running or not reachable.",
     "tryAgain": "Try again",
-    "reportThisIssue": "Report this issue"
+    "reportThisIssue": "Report this issue",
+    "opensInNewTab": "opens in new tab"
   },
   "nav": {
     "home": "Home",

--- a/packages/web/messages/es.json
+++ b/packages/web/messages/es.json
@@ -14,7 +14,8 @@
     "noResults": "No se encontraron resultados",
     "serverUnavailable": "No se puede conectar al servidor",
     "serverUnavailableDescription": "El servidor de contenido no está disponible actualmente. Esto generalmente significa que el backend no está funcionando o no es accesible.",
-    "tryAgain": "Reintentar"
+    "tryAgain": "Reintentar",
+    "reportThisIssue": "Reportar este problema"
   },
   "nav": {
     "home": "Inicio",

--- a/packages/web/messages/es.json
+++ b/packages/web/messages/es.json
@@ -15,7 +15,8 @@
     "serverUnavailable": "No se puede conectar al servidor",
     "serverUnavailableDescription": "El servidor de contenido no está disponible actualmente. Esto generalmente significa que el backend no está funcionando o no es accesible.",
     "tryAgain": "Reintentar",
-    "reportThisIssue": "Reportar este problema"
+    "reportThisIssue": "Reportar este problema",
+    "opensInNewTab": "se abre en una nueva pestaña"
   },
   "nav": {
     "home": "Inicio",

--- a/packages/web/messages/es.json
+++ b/packages/web/messages/es.json
@@ -58,7 +58,8 @@
     "ourArticles": "Nuestros artículos",
     "copyright": "© 2014 - {year} <strong>#play14</strong> desarrollado por <author>Cédric Pontet</author>",
     "privacyPolicy": "Política de privacidad",
-    "termsOfService": "Términos de servicio"
+    "termsOfService": "Términos de servicio",
+    "reportAnIssue": "Reportar un problema"
   },
   "home": {
     "powerOfPlay": {

--- a/packages/web/messages/fr.json
+++ b/packages/web/messages/fr.json
@@ -15,7 +15,8 @@
     "serverUnavailable": "Impossible de se connecter au serveur",
     "serverUnavailableDescription": "Le serveur de contenu est actuellement indisponible. Cela signifie généralement que le backend n'est pas en cours d'exécution ou n'est pas accessible.",
     "tryAgain": "Réessayer",
-    "reportThisIssue": "Signaler ce problème"
+    "reportThisIssue": "Signaler ce problème",
+    "opensInNewTab": "s'ouvre dans un nouvel onglet"
   },
   "nav": {
     "home": "Accueil",

--- a/packages/web/messages/fr.json
+++ b/packages/web/messages/fr.json
@@ -58,7 +58,8 @@
     "ourArticles": "Nos articles",
     "copyright": "© 2014 - {year} <strong>#play14</strong> développé par <author>Cédric Pontet</author>",
     "privacyPolicy": "Politique de confidentialité",
-    "termsOfService": "Conditions d'utilisation"
+    "termsOfService": "Conditions d'utilisation",
+    "reportAnIssue": "Signaler un problème"
   },
   "home": {
     "powerOfPlay": {

--- a/packages/web/messages/fr.json
+++ b/packages/web/messages/fr.json
@@ -14,7 +14,8 @@
     "noResults": "Aucun résultat trouvé",
     "serverUnavailable": "Impossible de se connecter au serveur",
     "serverUnavailableDescription": "Le serveur de contenu est actuellement indisponible. Cela signifie généralement que le backend n'est pas en cours d'exécution ou n'est pas accessible.",
-    "tryAgain": "Réessayer"
+    "tryAgain": "Réessayer",
+    "reportThisIssue": "Signaler ce problème"
   },
   "nav": {
     "home": "Accueil",

--- a/packages/web/messages/it.json
+++ b/packages/web/messages/it.json
@@ -15,7 +15,8 @@
     "serverUnavailable": "Impossibile connettersi al server",
     "serverUnavailableDescription": "Il server dei contenuti non è attualmente disponibile. Di solito significa che il backend non è in esecuzione o non è raggiungibile.",
     "tryAgain": "Riprova",
-    "reportThisIssue": "Segnala questo problema"
+    "reportThisIssue": "Segnala questo problema",
+    "opensInNewTab": "si apre in una nuova scheda"
   },
   "nav": {
     "home": "Home",

--- a/packages/web/messages/it.json
+++ b/packages/web/messages/it.json
@@ -58,7 +58,8 @@
     "ourArticles": "I nostri articoli",
     "copyright": "© 2014 - {year} <strong>#play14</strong> sviluppato da <author>Cédric Pontet</author>",
     "privacyPolicy": "Informativa sulla privacy",
-    "termsOfService": "Termini di servizio"
+    "termsOfService": "Termini di servizio",
+    "reportAnIssue": "Segnala un problema"
   },
   "home": {
     "powerOfPlay": {

--- a/packages/web/messages/it.json
+++ b/packages/web/messages/it.json
@@ -14,7 +14,8 @@
     "noResults": "Nessun risultato trovato",
     "serverUnavailable": "Impossibile connettersi al server",
     "serverUnavailableDescription": "Il server dei contenuti non è attualmente disponibile. Di solito significa che il backend non è in esecuzione o non è raggiungibile.",
-    "tryAgain": "Riprova"
+    "tryAgain": "Riprova",
+    "reportThisIssue": "Segnala questo problema"
   },
   "nav": {
     "home": "Home",

--- a/packages/web/src/app/[locale]/(main)/error.tsx
+++ b/packages/web/src/app/[locale]/(main)/error.tsx
@@ -38,6 +38,7 @@ export default function Error({
         }
         retryLabel={t("tryAgain")}
         onRetry={reset}
+        error={isConnectionError ? undefined : error}
       />
     </div>
   )

--- a/packages/web/src/app/[locale]/(main)/error.tsx
+++ b/packages/web/src/app/[locale]/(main)/error.tsx
@@ -38,6 +38,7 @@ export default function Error({
         }
         retryLabel={t("tryAgain")}
         onRetry={reset}
+        // Suppress the report link on connection errors — those aren't bugs to file.
         error={isConnectionError ? undefined : error}
       />
     </div>

--- a/packages/web/src/app/[locale]/(main)/events/error.tsx
+++ b/packages/web/src/app/[locale]/(main)/events/error.tsx
@@ -37,6 +37,7 @@ export default function EventsError({
             : undefined
         }
         onRetry={reset}
+        // Suppress the report link on connection errors — those aren't bugs to file.
         error={isConnectionError ? undefined : error}
       />
     </Page>

--- a/packages/web/src/app/[locale]/(main)/events/error.tsx
+++ b/packages/web/src/app/[locale]/(main)/events/error.tsx
@@ -37,6 +37,7 @@ export default function EventsError({
             : undefined
         }
         onRetry={reset}
+        error={isConnectionError ? undefined : error}
       />
     </Page>
   )

--- a/packages/web/src/app/global-error.tsx
+++ b/packages/web/src/app/global-error.tsx
@@ -3,13 +3,7 @@
 import { useEffect } from "react"
 import { useIssueReportUrl } from "@/hooks/use-issue-report-url"
 
-/**
- * Global error boundary that catches errors in the root layout.
- * This is a fallback for errors that escape all other error boundaries.
- *
- * Renders outside the next-intl provider, so user-facing strings are
- * intentionally hardcoded in English — `useTranslations` is not available.
- */
+// Renders outside the next-intl provider — strings are intentionally hardcoded in English.
 export default function GlobalError({
   error,
   reset,

--- a/packages/web/src/app/global-error.tsx
+++ b/packages/web/src/app/global-error.tsx
@@ -6,6 +6,9 @@ import { buildIssueReportUrl } from "@/libs/issue-report"
 /**
  * Global error boundary that catches errors in the root layout.
  * This is a fallback for errors that escape all other error boundaries.
+ *
+ * Renders outside the next-intl provider, so user-facing strings are
+ * intentionally hardcoded in English — `useTranslations` is not available.
  */
 export default function GlobalError({
   error,

--- a/packages/web/src/app/global-error.tsx
+++ b/packages/web/src/app/global-error.tsx
@@ -88,7 +88,7 @@ export default function GlobalError({
                 href={issueUrl}
                 target="_blank"
                 rel="noreferrer"
-                style={{ color: "#666", textDecoration: "underline", fontSize: "0.9rem" }}
+                style={{ color: "#888", textDecoration: "underline", fontSize: "0.875rem" }}
               >
                 Report this issue
               </a>

--- a/packages/web/src/app/global-error.tsx
+++ b/packages/web/src/app/global-error.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import { useEffect, useState } from "react"
-import { buildIssueReportUrl } from "@/libs/issue-report"
+import { useEffect } from "react"
+import { useIssueReportUrl } from "@/hooks/use-issue-report-url"
 
 /**
  * Global error boundary that catches errors in the root layout.
@@ -17,19 +17,10 @@ export default function GlobalError({
   error: Error & { digest?: string }
   reset: () => void
 }) {
-  const [issueUrl, setIssueUrl] = useState<string | null>(null)
+  const issueUrl = useIssueReportUrl(error)
 
   useEffect(() => {
     console.error("Global error:", error)
-    setIssueUrl(
-      buildIssueReportUrl({
-        errorMessage: error.message,
-        errorDigest: error.digest,
-        errorStack: error.stack,
-        pageUrl: window.location.href,
-        userAgent: navigator.userAgent,
-      })
-    )
   }, [error])
 
   return (

--- a/packages/web/src/app/global-error.tsx
+++ b/packages/web/src/app/global-error.tsx
@@ -26,8 +26,8 @@ export default function GlobalError({
         errorMessage: error.message,
         errorDigest: error.digest,
         errorStack: error.stack,
-        pageUrl: typeof window !== "undefined" ? window.location.href : undefined,
-        userAgent: typeof navigator !== "undefined" ? navigator.userAgent : undefined,
+        pageUrl: window.location.href,
+        userAgent: navigator.userAgent,
       })
     )
   }, [error])
@@ -91,6 +91,7 @@ export default function GlobalError({
                 href={issueUrl}
                 target="_blank"
                 rel="noreferrer"
+                aria-label="Report this issue (opens in new tab)"
                 style={{ color: "#888", textDecoration: "underline", fontSize: "0.875rem" }}
               >
                 Report this issue

--- a/packages/web/src/app/global-error.tsx
+++ b/packages/web/src/app/global-error.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
+import { buildIssueReportUrl } from "@/libs/issue-report"
 
 /**
  * Global error boundary that catches errors in the root layout.
@@ -13,8 +14,19 @@ export default function GlobalError({
   error: Error & { digest?: string }
   reset: () => void
 }) {
+  const [issueUrl, setIssueUrl] = useState<string | null>(null)
+
   useEffect(() => {
     console.error("Global error:", error)
+    setIssueUrl(
+      buildIssueReportUrl({
+        errorMessage: error.message,
+        errorDigest: error.digest,
+        errorStack: error.stack,
+        pageUrl: typeof window !== "undefined" ? window.location.href : undefined,
+        userAgent: typeof navigator !== "undefined" ? navigator.userAgent : undefined,
+      })
+    )
   }, [error])
 
   return (
@@ -44,23 +56,44 @@ export default function GlobalError({
           >
             An unexpected error occurred. Our team has been notified and is working to fix it.
           </p>
-          <button
-            onClick={reset}
+          <div
             style={{
-              padding: "0.75rem 1.5rem",
-              fontSize: "1rem",
-              backgroundColor: "#0070f3",
-              color: "white",
-              border: "none",
-              borderRadius: "0.5rem",
-              cursor: "pointer",
-              transition: "background-color 0.2s",
+              display: "flex",
+              gap: "1rem",
+              alignItems: "center",
+              flexWrap: "wrap",
+              justifyContent: "center",
             }}
-            onMouseOver={(e) => (e.currentTarget.style.backgroundColor = "#0060df")}
-            onMouseOut={(e) => (e.currentTarget.style.backgroundColor = "#0070f3")}
           >
-            Try again
-          </button>
+            <button
+              type="button"
+              onClick={reset}
+              style={{
+                padding: "0.75rem 1.5rem",
+                fontSize: "1rem",
+                backgroundColor: "#0070f3",
+                color: "white",
+                border: "none",
+                borderRadius: "0.5rem",
+                cursor: "pointer",
+                transition: "background-color 0.2s",
+              }}
+              onMouseOver={(e) => (e.currentTarget.style.backgroundColor = "#0060df")}
+              onMouseOut={(e) => (e.currentTarget.style.backgroundColor = "#0070f3")}
+            >
+              Try again
+            </button>
+            {issueUrl && (
+              <a
+                href={issueUrl}
+                target="_blank"
+                rel="noreferrer"
+                style={{ color: "#666", textDecoration: "underline", fontSize: "0.9rem" }}
+              >
+                Report this issue
+              </a>
+            )}
+          </div>
           {error.digest && (
             <p
               style={{

--- a/packages/web/src/components/layout/error-message.tsx
+++ b/packages/web/src/components/layout/error-message.tsx
@@ -36,8 +36,8 @@ export default function ErrorMessage({
         errorMessage: error.message,
         errorDigest: error.digest,
         errorStack: error.stack,
-        pageUrl: typeof window !== "undefined" ? window.location.href : undefined,
-        userAgent: typeof navigator !== "undefined" ? navigator.userAgent : undefined,
+        pageUrl: window.location.href,
+        userAgent: navigator.userAgent,
       })
     )
   }, [error])
@@ -98,6 +98,7 @@ export default function ErrorMessage({
                 href={issueUrl}
                 target="_blank"
                 rel="noreferrer"
+                aria-label={`${t("reportThisIssue")} (opens in new tab)`}
                 style={{ color: "var(--color-text-secondary)", textDecoration: "underline" }}
               >
                 {t("reportThisIssue")}

--- a/packages/web/src/components/layout/error-message.tsx
+++ b/packages/web/src/components/layout/error-message.tsx
@@ -11,7 +11,7 @@ interface ErrorMessageProps {
   showReload?: boolean
   retryLabel?: string
   onRetry?: () => void
-  error?: { message?: string; digest?: string; stack?: string }
+  error?: Error & { digest?: string }
 }
 
 export default function ErrorMessage({
@@ -24,24 +24,23 @@ export default function ErrorMessage({
   error,
 }: ErrorMessageProps) {
   const t = useTranslations("common")
-  const showReportLink = Boolean(error)
   const [issueUrl, setIssueUrl] = useState<string | null>(null)
 
   useEffect(() => {
-    if (!showReportLink) {
+    if (!error) {
       setIssueUrl(null)
       return
     }
     setIssueUrl(
       buildIssueReportUrl({
-        errorMessage: error?.message,
-        errorDigest: error?.digest,
-        errorStack: error?.stack,
+        errorMessage: error.message,
+        errorDigest: error.digest,
+        errorStack: error.stack,
         pageUrl: typeof window !== "undefined" ? window.location.href : undefined,
         userAgent: typeof navigator !== "undefined" ? navigator.userAgent : undefined,
       })
     )
-  }, [showReportLink, error?.message, error?.digest, error?.stack])
+  }, [error])
 
   const handleRetry = () => {
     if (onRetry) {

--- a/packages/web/src/components/layout/error-message.tsx
+++ b/packages/web/src/components/layout/error-message.tsx
@@ -81,6 +81,7 @@ export default function ErrorMessage({
                 href={issueUrl}
                 target="_blank"
                 rel="noreferrer"
+                aria-label={`${t("reportThisIssue")} (${t("opensInNewTab")})`}
                 style={{ color: "var(--color-text-secondary)", textDecoration: "underline" }}
               >
                 {t("reportThisIssue")}

--- a/packages/web/src/components/layout/error-message.tsx
+++ b/packages/web/src/components/layout/error-message.tsx
@@ -98,7 +98,6 @@ export default function ErrorMessage({
                 href={issueUrl}
                 target="_blank"
                 rel="noreferrer"
-                aria-label={`${t("reportThisIssue")} (opens in new tab)`}
                 style={{ color: "var(--color-text-secondary)", textDecoration: "underline" }}
               >
                 {t("reportThisIssue")}

--- a/packages/web/src/components/layout/error-message.tsx
+++ b/packages/web/src/components/layout/error-message.tsx
@@ -1,5 +1,9 @@
 "use client"
 
+import { useTranslations } from "next-intl"
+import { useEffect, useState } from "react"
+import { buildIssueReportUrl } from "@/libs/issue-report"
+
 interface ErrorMessageProps {
   title?: string
   message: string
@@ -7,6 +11,8 @@ interface ErrorMessageProps {
   showReload?: boolean
   retryLabel?: string
   onRetry?: () => void
+  error?: { message?: string; digest?: string; stack?: string }
+  reportable?: boolean
 }
 
 export default function ErrorMessage({
@@ -16,7 +22,29 @@ export default function ErrorMessage({
   showReload = true,
   retryLabel = "Retry",
   onRetry,
+  error,
+  reportable,
 }: ErrorMessageProps) {
+  const t = useTranslations("common")
+  const showReportLink = reportable ?? Boolean(error)
+  const [issueUrl, setIssueUrl] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!showReportLink) {
+      setIssueUrl(null)
+      return
+    }
+    setIssueUrl(
+      buildIssueReportUrl({
+        errorMessage: error?.message,
+        errorDigest: error?.digest,
+        errorStack: error?.stack,
+        pageUrl: typeof window !== "undefined" ? window.location.href : undefined,
+        userAgent: typeof navigator !== "undefined" ? navigator.userAgent : undefined,
+      })
+    )
+  }, [showReportLink, error?.message, error?.digest, error?.stack])
+
   const handleRetry = () => {
     if (onRetry) {
       onRetry()
@@ -53,11 +81,31 @@ export default function ErrorMessage({
             </pre>
           </div>
         )}
-        {showReload && (
-          <div style={{ marginTop: "1.5rem" }}>
-            <button type="button" className="btn btn-primary" onClick={handleRetry}>
-              {retryLabel}
-            </button>
+        {(showReload || issueUrl) && (
+          <div
+            style={{
+              marginTop: "1.5rem",
+              display: "flex",
+              gap: "0.75rem",
+              flexWrap: "wrap",
+              alignItems: "center",
+            }}
+          >
+            {showReload && (
+              <button type="button" className="btn btn-primary" onClick={handleRetry}>
+                {retryLabel}
+              </button>
+            )}
+            {issueUrl && (
+              <a
+                href={issueUrl}
+                target="_blank"
+                rel="noreferrer"
+                style={{ color: "var(--color-text-secondary)", textDecoration: "underline" }}
+              >
+                {t("reportThisIssue")}
+              </a>
+            )}
           </div>
         )}
       </div>

--- a/packages/web/src/components/layout/error-message.tsx
+++ b/packages/web/src/components/layout/error-message.tsx
@@ -12,7 +12,6 @@ interface ErrorMessageProps {
   retryLabel?: string
   onRetry?: () => void
   error?: { message?: string; digest?: string; stack?: string }
-  reportable?: boolean
 }
 
 export default function ErrorMessage({
@@ -23,10 +22,9 @@ export default function ErrorMessage({
   retryLabel = "Retry",
   onRetry,
   error,
-  reportable,
 }: ErrorMessageProps) {
   const t = useTranslations("common")
-  const showReportLink = reportable ?? Boolean(error)
+  const showReportLink = Boolean(error)
   const [issueUrl, setIssueUrl] = useState<string | null>(null)
 
   useEffect(() => {

--- a/packages/web/src/components/layout/error-message.tsx
+++ b/packages/web/src/components/layout/error-message.tsx
@@ -1,8 +1,7 @@
 "use client"
 
 import { useTranslations } from "next-intl"
-import { useEffect, useState } from "react"
-import { buildIssueReportUrl } from "@/libs/issue-report"
+import { useIssueReportUrl } from "@/hooks/use-issue-report-url"
 
 interface ErrorMessageProps {
   title?: string
@@ -24,23 +23,7 @@ export default function ErrorMessage({
   error,
 }: ErrorMessageProps) {
   const t = useTranslations("common")
-  const [issueUrl, setIssueUrl] = useState<string | null>(null)
-
-  useEffect(() => {
-    if (!error) {
-      setIssueUrl(null)
-      return
-    }
-    setIssueUrl(
-      buildIssueReportUrl({
-        errorMessage: error.message,
-        errorDigest: error.digest,
-        errorStack: error.stack,
-        pageUrl: window.location.href,
-        userAgent: navigator.userAgent,
-      })
-    )
-  }, [error])
+  const issueUrl = useIssueReportUrl(error)
 
   const handleRetry = () => {
     if (onRetry) {

--- a/packages/web/src/components/layout/footer.tsx
+++ b/packages/web/src/components/layout/footer.tsx
@@ -139,6 +139,15 @@ const Footer = async () => {
                 <li>
                   <I18nLink href="/terms">{t("termsOfService")}</I18nLink>
                 </li>
+                <li>
+                  <Link
+                    href="https://github.com/play14team/play14/issues/new?template=bug_report.yml"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    {t("reportAnIssue")}
+                  </Link>
+                </li>
               </ul>
             </div>
           </div>

--- a/packages/web/src/components/layout/footer.tsx
+++ b/packages/web/src/components/layout/footer.tsx
@@ -31,7 +31,7 @@ const socialLinks = [
 ]
 
 const Footer = async () => {
-  const t = await getTranslations("footer")
+  const tFooter = await getTranslations("footer")
   const tCommon = await getTranslations("common")
   const currentYear = new Date().getFullYear()
 
@@ -44,7 +44,7 @@ const Footer = async () => {
               <I18nLink href="/" className="logo d-inline-block">
                 <Logo width={250} height={83} />
               </I18nLink>
-              <p className="mt-3">{t("tagline")}</p>
+              <p className="mt-3">{tFooter("tagline")}</p>
 
               <ul className="social-link justify-content-center">
                 {socialLinks.map((action, index) => {
@@ -68,24 +68,24 @@ const Footer = async () => {
 
           <div className="col-lg-4 col-sm-6">
             <div className="single-footer-widget">
-              <h3>{t("stayUpdated")}</h3>
+              <h3>{tFooter("stayUpdated")}</h3>
               <NewsletterSignup source="footer" />
             </div>
           </div>
 
           <div className="col-lg-2 col-sm-6 ps-lg-5">
             <div className="single-footer-widget">
-              <h3>{t("explore")}</h3>
+              <h3>{tFooter("explore")}</h3>
 
               <ul className="footer-links-list">
                 <li>
-                  <I18nLink href="/">{t("home")}</I18nLink>
+                  <I18nLink href="/">{tFooter("home")}</I18nLink>
                 </li>
                 <li>
-                  <I18nLink href="/about/story">{t("about")}</I18nLink>
+                  <I18nLink href="/about/story">{tFooter("about")}</I18nLink>
                 </li>
                 <li>
-                  <I18nLink href="/contact">{t("contact")}</I18nLink>
+                  <I18nLink href="/contact">{tFooter("contact")}</I18nLink>
                 </li>
               </ul>
             </div>
@@ -93,20 +93,20 @@ const Footer = async () => {
 
           <div className="col-lg-3 col-sm-6">
             <div className="single-footer-widget">
-              <h3>{t("resources")}</h3>
+              <h3>{tFooter("resources")}</h3>
 
               <ul className="footer-links-list">
                 <li>
-                  <I18nLink href="/events">{t("ourEvents")}</I18nLink>
+                  <I18nLink href="/events">{tFooter("ourEvents")}</I18nLink>
                 </li>
                 <li>
-                  <I18nLink href="/players">{t("ourPlayers")}</I18nLink>
+                  <I18nLink href="/players">{tFooter("ourPlayers")}</I18nLink>
                 </li>
                 <li>
-                  <I18nLink href="/games">{t("ourGames")}</I18nLink>
+                  <I18nLink href="/games">{tFooter("ourGames")}</I18nLink>
                 </li>
                 <li>
-                  <I18nLink href="/articles">{t("ourArticles")}</I18nLink>
+                  <I18nLink href="/articles">{tFooter("ourArticles")}</I18nLink>
                 </li>
               </ul>
             </div>
@@ -117,7 +117,7 @@ const Footer = async () => {
           <div className="row align-items-center">
             <div className="col-lg-6 col-md-6">
               <p>
-                {t.rich("copyright", {
+                {tFooter.rich("copyright", {
                   year: currentYear,
                   strong: (chunks) => <strong>{chunks}</strong>,
                   author: (chunks) => (
@@ -136,10 +136,10 @@ const Footer = async () => {
             <div className="col-lg-6 col-md-6">
               <ul>
                 <li>
-                  <I18nLink href="/privacy">{t("privacyPolicy")}</I18nLink>
+                  <I18nLink href="/privacy">{tFooter("privacyPolicy")}</I18nLink>
                 </li>
                 <li>
-                  <I18nLink href="/terms">{t("termsOfService")}</I18nLink>
+                  <I18nLink href="/terms">{tFooter("termsOfService")}</I18nLink>
                 </li>
                 <li>
                   {/* buildIssueReportUrl with no args — hook unavailable in Server Components. */}
@@ -147,9 +147,9 @@ const Footer = async () => {
                     href={buildIssueReportUrl()}
                     target="_blank"
                     rel="noreferrer"
-                    aria-label={`${t("reportAnIssue")} (${tCommon("opensInNewTab")})`}
+                    aria-label={`${tFooter("reportAnIssue")} (${tCommon("opensInNewTab")})`}
                   >
-                    {t("reportAnIssue")}
+                    {tFooter("reportAnIssue")}
                   </a>
                 </li>
               </ul>

--- a/packages/web/src/components/layout/footer.tsx
+++ b/packages/web/src/components/layout/footer.tsx
@@ -141,11 +141,10 @@ const Footer = async () => {
                   <I18nLink href="/terms">{t("termsOfService")}</I18nLink>
                 </li>
                 <li>
-                  {/* Server-rendered: the footer link is intentionally static. Don't add
-                      window-dependent context here — it would break SSR. */}
-                  <Link href={buildIssueReportUrl()} target="_blank" rel="noreferrer">
+                  {/* Server-rendered: keep this URL context-free, no window/navigator. */}
+                  <a href={buildIssueReportUrl()} target="_blank" rel="noreferrer">
                     {t("reportAnIssue")}
-                  </Link>
+                  </a>
                 </li>
               </ul>
             </div>

--- a/packages/web/src/components/layout/footer.tsx
+++ b/packages/web/src/components/layout/footer.tsx
@@ -142,7 +142,7 @@ const Footer = async () => {
                   <I18nLink href="/terms">{t("termsOfService")}</I18nLink>
                 </li>
                 <li>
-                  {/* Server-rendered: keep this URL context-free, no window/navigator. */}
+                  {/* buildIssueReportUrl with no args — hook unavailable in Server Components. */}
                   <a
                     href={buildIssueReportUrl()}
                     target="_blank"

--- a/packages/web/src/components/layout/footer.tsx
+++ b/packages/web/src/components/layout/footer.tsx
@@ -141,7 +141,12 @@ const Footer = async () => {
                   <I18nLink href="/terms">{t("termsOfService")}</I18nLink>
                 </li>
                 <li>
-                  <Link href={buildIssueReportUrl()} target="_blank" rel="noreferrer">
+                  <Link
+                    href={buildIssueReportUrl()}
+                    target="_blank"
+                    rel="noreferrer"
+                    aria-label={`${t("reportAnIssue")} (opens in new tab)`}
+                  >
                     {t("reportAnIssue")}
                   </Link>
                 </li>

--- a/packages/web/src/components/layout/footer.tsx
+++ b/packages/web/src/components/layout/footer.tsx
@@ -141,12 +141,9 @@ const Footer = async () => {
                   <I18nLink href="/terms">{t("termsOfService")}</I18nLink>
                 </li>
                 <li>
-                  <Link
-                    href={buildIssueReportUrl()}
-                    target="_blank"
-                    rel="noreferrer"
-                    aria-label={`${t("reportAnIssue")} (opens in new tab)`}
-                  >
+                  {/* Server-rendered: the footer link is intentionally static. Don't add
+                      window-dependent context here — it would break SSR. */}
+                  <Link href={buildIssueReportUrl()} target="_blank" rel="noreferrer">
                     {t("reportAnIssue")}
                   </Link>
                 </li>

--- a/packages/web/src/components/layout/footer.tsx
+++ b/packages/web/src/components/layout/footer.tsx
@@ -3,6 +3,7 @@ import Link from "next/link"
 import { getTranslations } from "next-intl/server"
 import NewsletterSignup from "@/components/newsletter/newsletter-signup"
 import { Link as I18nLink } from "@/i18n/navigation"
+import { buildIssueReportUrl } from "@/libs/issue-report"
 import footerMap from "@/styles/images/footer-map.png"
 import Logo from "./logo"
 
@@ -140,11 +141,7 @@ const Footer = async () => {
                   <I18nLink href="/terms">{t("termsOfService")}</I18nLink>
                 </li>
                 <li>
-                  <Link
-                    href="https://github.com/play14team/play14/issues/new?template=bug_report.yml"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
+                  <Link href={buildIssueReportUrl()} target="_blank" rel="noreferrer">
                     {t("reportAnIssue")}
                   </Link>
                 </li>

--- a/packages/web/src/components/layout/footer.tsx
+++ b/packages/web/src/components/layout/footer.tsx
@@ -32,6 +32,7 @@ const socialLinks = [
 
 const Footer = async () => {
   const t = await getTranslations("footer")
+  const tCommon = await getTranslations("common")
   const currentYear = new Date().getFullYear()
 
   return (
@@ -142,7 +143,12 @@ const Footer = async () => {
                 </li>
                 <li>
                   {/* Server-rendered: keep this URL context-free, no window/navigator. */}
-                  <a href={buildIssueReportUrl()} target="_blank" rel="noreferrer">
+                  <a
+                    href={buildIssueReportUrl()}
+                    target="_blank"
+                    rel="noreferrer"
+                    aria-label={`${t("reportAnIssue")} (${tCommon("opensInNewTab")})`}
+                  >
                     {t("reportAnIssue")}
                   </a>
                 </li>

--- a/packages/web/src/hooks/use-issue-report-url.ts
+++ b/packages/web/src/hooks/use-issue-report-url.ts
@@ -13,6 +13,8 @@ import { buildIssueReportUrl } from "@/libs/issue-report"
 export function useIssueReportUrl(error: (Error & { digest?: string }) | undefined): string | null {
   const [issueUrl, setIssueUrl] = useState<string | null>(null)
 
+  // [error] is a stable reference per render of an error boundary — Next.js
+  // hands the same Error instance on every re-render until reset() runs.
   useEffect(() => {
     if (!error) {
       setIssueUrl(null)
@@ -23,7 +25,9 @@ export function useIssueReportUrl(error: (Error & { digest?: string }) | undefin
         errorMessage: error.message,
         errorDigest: error.digest,
         errorStack: error.stack,
-        pageUrl: window.location.href,
+        // Strip query + hash so auth tokens / search terms / IDs in the
+        // current URL don't get pre-filled into the public issue body.
+        pageUrl: `${window.location.origin}${window.location.pathname}`,
         userAgent: navigator.userAgent,
       })
     )

--- a/packages/web/src/hooks/use-issue-report-url.ts
+++ b/packages/web/src/hooks/use-issue-report-url.ts
@@ -7,7 +7,7 @@ import { buildIssueReportUrl, issueReportContextFromError } from "@/libs/issue-r
 export function useIssueReportUrl(error: (Error & { digest?: string }) | undefined): string | null {
   const [issueUrl, setIssueUrl] = useState<string | null>(null)
 
-  // [error] is stable per boundary — Next.js hands the same Error instance until reset() runs.
+  // New Error reference → re-derive the URL; same reference → no-op. Correct in either case.
   useEffect(() => {
     if (!error) {
       setIssueUrl(null)

--- a/packages/web/src/hooks/use-issue-report-url.ts
+++ b/packages/web/src/hooks/use-issue-report-url.ts
@@ -3,18 +3,11 @@
 import { useEffect, useState } from "react"
 import { buildIssueReportUrl, issueReportContextFromError } from "@/libs/issue-report"
 
-/**
- * Builds a GitHub issue-report URL pre-filled with the captured error and the
- * current page context. The work happens in a `useEffect` because
- * `window.location` and `navigator.userAgent` aren't available during SSR —
- * so the link briefly appears after hydration, which is intentional.
- * `useMemo` won't work here for the same reason.
- */
+// useEffect, not useMemo: window/navigator aren't available during SSR, so the URL is set post-hydration.
 export function useIssueReportUrl(error: (Error & { digest?: string }) | undefined): string | null {
   const [issueUrl, setIssueUrl] = useState<string | null>(null)
 
-  // [error] is a stable reference per render of an error boundary — Next.js
-  // hands the same Error instance on every re-render until reset() runs.
+  // [error] is stable per boundary — Next.js hands the same Error instance until reset() runs.
   useEffect(() => {
     if (!error) {
       setIssueUrl(null)

--- a/packages/web/src/hooks/use-issue-report-url.ts
+++ b/packages/web/src/hooks/use-issue-report-url.ts
@@ -1,0 +1,33 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { buildIssueReportUrl } from "@/libs/issue-report"
+
+/**
+ * Builds a GitHub issue-report URL pre-filled with the captured error and the
+ * current page context. The work happens in a `useEffect` because
+ * `window.location.href` and `navigator.userAgent` aren't available during
+ * SSR — so the link briefly appears after hydration, which is intentional.
+ * `useMemo` won't work here for the same reason.
+ */
+export function useIssueReportUrl(error: (Error & { digest?: string }) | undefined): string | null {
+  const [issueUrl, setIssueUrl] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!error) {
+      setIssueUrl(null)
+      return
+    }
+    setIssueUrl(
+      buildIssueReportUrl({
+        errorMessage: error.message,
+        errorDigest: error.digest,
+        errorStack: error.stack,
+        pageUrl: window.location.href,
+        userAgent: navigator.userAgent,
+      })
+    )
+  }, [error])
+
+  return issueUrl
+}

--- a/packages/web/src/hooks/use-issue-report-url.ts
+++ b/packages/web/src/hooks/use-issue-report-url.ts
@@ -1,13 +1,13 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import { buildIssueReportUrl } from "@/libs/issue-report"
+import { buildIssueReportUrl, issueReportContextFromError } from "@/libs/issue-report"
 
 /**
  * Builds a GitHub issue-report URL pre-filled with the captured error and the
  * current page context. The work happens in a `useEffect` because
- * `window.location.href` and `navigator.userAgent` aren't available during
- * SSR — so the link briefly appears after hydration, which is intentional.
+ * `window.location` and `navigator.userAgent` aren't available during SSR —
+ * so the link briefly appears after hydration, which is intentional.
  * `useMemo` won't work here for the same reason.
  */
 export function useIssueReportUrl(error: (Error & { digest?: string }) | undefined): string | null {
@@ -20,17 +20,7 @@ export function useIssueReportUrl(error: (Error & { digest?: string }) | undefin
       setIssueUrl(null)
       return
     }
-    setIssueUrl(
-      buildIssueReportUrl({
-        errorMessage: error.message,
-        errorDigest: error.digest,
-        errorStack: error.stack,
-        // Strip query + hash so auth tokens / search terms / IDs in the
-        // current URL don't get pre-filled into the public issue body.
-        pageUrl: `${window.location.origin}${window.location.pathname}`,
-        userAgent: navigator.userAgent,
-      })
-    )
+    setIssueUrl(buildIssueReportUrl(issueReportContextFromError(error, window.location, navigator)))
   }, [error])
 
   return issueUrl

--- a/packages/web/src/libs/issue-report.test.ts
+++ b/packages/web/src/libs/issue-report.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest"
+import { buildIssueReportUrl } from "./issue-report"
+
+const BASE = "https://github.com/play14team/play14/issues/new"
+
+describe("buildIssueReportUrl", () => {
+  it("returns the bare template URL when no context is provided", () => {
+    const url = new URL(buildIssueReportUrl())
+    expect(`${url.origin}${url.pathname}`).toBe(BASE)
+    expect(url.searchParams.get("template")).toBe("bug_report.yml")
+    expect(url.searchParams.has("title")).toBe(false)
+    expect(url.searchParams.has("what-happened")).toBe(false)
+  })
+
+  it("prefills title and what-happened from the error message", () => {
+    const url = new URL(
+      buildIssueReportUrl({
+        errorMessage: "Cannot read property 'foo' of undefined",
+        errorDigest: "abc123",
+      })
+    )
+    expect(url.searchParams.get("title")).toBe("[Bug]: Cannot read property 'foo' of undefined")
+    const what = url.searchParams.get("what-happened") ?? ""
+    expect(what).toContain("Cannot read property 'foo' of undefined")
+    expect(what).toContain("abc123")
+  })
+
+  it("falls back to the digest when no error message is available", () => {
+    const url = new URL(buildIssueReportUrl({ errorDigest: "abc123" }))
+    expect(url.searchParams.get("title")).toBe("[Bug]: error abc123")
+    expect(url.searchParams.get("what-happened")).toContain("abc123")
+  })
+
+  it("propagates page URL and user agent to the issue form", () => {
+    const url = new URL(
+      buildIssueReportUrl({
+        pageUrl: "https://play14.org/events",
+        userAgent: "Mozilla/5.0",
+      })
+    )
+    expect(url.searchParams.get("page-url")).toBe("https://play14.org/events")
+    expect(url.searchParams.get("additional-context")).toContain("Mozilla/5.0")
+  })
+
+  it("caps the title length so the URL stays short", () => {
+    const long = "x".repeat(500)
+    const url = new URL(buildIssueReportUrl({ errorMessage: long }))
+    expect((url.searchParams.get("title") ?? "").length).toBeLessThanOrEqual(200)
+  })
+
+  it("truncates the stack trace to keep the URL under GitHub's limit", () => {
+    const stack = "frame\n".repeat(1000)
+    const url = new URL(buildIssueReportUrl({ errorStack: stack }))
+    const context = url.searchParams.get("additional-context") ?? ""
+    expect(context).toContain("Stack trace:")
+    expect(context.length).toBeLessThan(2500)
+  })
+})

--- a/packages/web/src/libs/issue-report.test.ts
+++ b/packages/web/src/libs/issue-report.test.ts
@@ -94,4 +94,14 @@ describe("buildIssueReportUrl", () => {
     expect(url.length).toBeLessThanOrEqual(8000)
     expect(new URL(url).searchParams.has("additional-context")).toBe(false)
   })
+
+  it("falls back to the bare template when even the trimmed URL is too long", () => {
+    // A 10 KB pageUrl alone exceeds the limit; the builder should return a
+    // bare-template URL rather than slice mid percent-encoding.
+    const url = buildIssueReportUrl({
+      pageUrl: `https://play14.org/${"x".repeat(10_000)}`,
+    })
+    expect(url).toBe("https://github.com/play14team/play14/issues/new?template=bug_report.yml")
+    expect(new URL(url).searchParams.get("template")).toBe("bug_report.yml")
+  })
 })

--- a/packages/web/src/libs/issue-report.test.ts
+++ b/packages/web/src/libs/issue-report.test.ts
@@ -69,4 +69,29 @@ describe("buildIssueReportUrl", () => {
     expect(context).toContain("at fn (file.ts:1:1)")
     expect(context.indexOf("Mozilla/5.0")).toBeLessThan(context.indexOf("Stack trace:"))
   })
+
+  it("scrubs absolute filesystem paths from the stack trace", () => {
+    const stack = [
+      "Error: boom",
+      "    at handler (/home/user/play14/packages/web/src/foo.ts:12:5)",
+      "    at /home/user/play14/node_modules/next/dist/server.js:99:1",
+    ].join("\n")
+    const url = new URL(buildIssueReportUrl({ errorStack: stack }))
+    const context = url.searchParams.get("additional-context") ?? ""
+    expect(context).not.toContain("/home/user/play14")
+    expect(context).toContain("<path>")
+  })
+
+  it("drops additional-context when the final URL would exceed GitHub's limit", () => {
+    // A very long pageUrl bypasses every per-field cap, so the URL builder must
+    // fall back to dropping the verbose additional-context block to stay short.
+    const url = buildIssueReportUrl({
+      errorMessage: "boom",
+      pageUrl: `https://play14.org/${"x".repeat(6000)}`,
+      errorStack: "y".repeat(2000),
+      userAgent: "Mozilla/5.0",
+    })
+    expect(url.length).toBeLessThanOrEqual(8000)
+    expect(new URL(url).searchParams.has("additional-context")).toBe(false)
+  })
 })

--- a/packages/web/src/libs/issue-report.test.ts
+++ b/packages/web/src/libs/issue-report.test.ts
@@ -55,4 +55,18 @@ describe("buildIssueReportUrl", () => {
     expect(context).toContain("Stack trace:")
     expect(context.length).toBeLessThan(2500)
   })
+
+  it("joins user agent and stack trace into a single additional-context block", () => {
+    const url = new URL(
+      buildIssueReportUrl({
+        userAgent: "Mozilla/5.0",
+        errorStack: "at fn (file.ts:1:1)",
+      })
+    )
+    const context = url.searchParams.get("additional-context") ?? ""
+    expect(context).toContain("**User agent:** Mozilla/5.0")
+    expect(context).toContain("**Stack trace:**")
+    expect(context).toContain("at fn (file.ts:1:1)")
+    expect(context.indexOf("Mozilla/5.0")).toBeLessThan(context.indexOf("Stack trace:"))
+  })
 })

--- a/packages/web/src/libs/issue-report.test.ts
+++ b/packages/web/src/libs/issue-report.test.ts
@@ -66,6 +66,30 @@ describe("buildIssueReportUrl", () => {
     expect(stackBlock).toMatch(/\nabc\n…$/)
   })
 
+  it("scrubs absolute paths regardless of their root segment", () => {
+    const stack = [
+      "Error: boom",
+      "    at writer (/workspace/builds/play14/foo.ts:1:1)",
+      "    at proc (/proc/self/fd/3:2:2)",
+    ].join("\n")
+    const url = new URL(buildIssueReportUrl({ errorStack: stack }))
+    const context = url.searchParams.get("additional-context") ?? ""
+    expect(context).not.toContain("/workspace/builds")
+    expect(context).not.toContain("/proc/self")
+    expect(context.match(/<path>/g)?.length ?? 0).toBeGreaterThanOrEqual(2)
+  })
+
+  it("does not rewrite the scheme of URLs that appear in error text", () => {
+    // The lookbehind in UNIX_PATH_RE skips the `://` in scheme-based URLs so
+    // `https://host/...` keeps its scheme. The path suffix may still be
+    // redacted — acceptable since `pageUrl` carries the canonical URL separately.
+    const url = new URL(
+      buildIssueReportUrl({ errorMessage: "fetch failed: GET https://api.play14.org/events" })
+    )
+    const what = url.searchParams.get("what-happened") ?? ""
+    expect(what).toContain("https://api.play14.org")
+  })
+
   it("scrubs Windows-style absolute paths from the stack trace", () => {
     const stack = [
       "Error: boom",

--- a/packages/web/src/libs/issue-report.test.ts
+++ b/packages/web/src/libs/issue-report.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { buildIssueReportUrl } from "./issue-report"
+import { buildIssueReportUrl, issueReportContextFromError } from "./issue-report"
 
 const BASE = "https://github.com/play14team/play14/issues/new"
 
@@ -125,5 +125,64 @@ describe("buildIssueReportUrl", () => {
     })
     expect(url).toBe("https://github.com/play14team/play14/issues/new?template=bug_report.yml")
     expect(new URL(url).searchParams.get("template")).toBe("bug_report.yml")
+  })
+
+  it("scrubs absolute filesystem paths from the error message", () => {
+    const url = new URL(
+      buildIssueReportUrl({
+        errorMessage:
+          "ENOENT: no such file or directory, open '/home/runner/work/play14/secret.env'",
+      })
+    )
+    const title = url.searchParams.get("title") ?? ""
+    const what = url.searchParams.get("what-happened") ?? ""
+    expect(title).not.toContain("/home/runner/work")
+    expect(what).not.toContain("/home/runner/work")
+    expect(what).toContain("<path>")
+  })
+
+  it("preserves newlines in the body but flattens them in the title", () => {
+    const url = new URL(
+      buildIssueReportUrl({
+        errorMessage: "Boom\n  caused by deeper issue\n  on line 3",
+      })
+    )
+    expect(url.searchParams.get("title")).toBe("[Bug]: Boom caused by deeper issue on line 3")
+    const what = url.searchParams.get("what-happened") ?? ""
+    // Horizontal whitespace collapses to a single space, newlines survive.
+    expect(what).toContain("Boom\n caused by deeper issue\n on line 3")
+  })
+})
+
+describe("issueReportContextFromError", () => {
+  const location = { origin: "https://play14.org", pathname: "/events/abc" }
+  const ua = { userAgent: "Mozilla/5.0" }
+
+  it("strips query parameters and the fragment from the page URL", () => {
+    const error = new Error("boom")
+    // Simulate a URL that carries query + hash; the helper should only keep origin+pathname.
+    const dirtyLocation = {
+      origin: "https://play14.org",
+      pathname: "/events/abc",
+    }
+    const ctx = issueReportContextFromError(error, dirtyLocation, ua)
+    expect(ctx.pageUrl).toBe("https://play14.org/events/abc")
+    expect(ctx.pageUrl).not.toContain("?")
+    expect(ctx.pageUrl).not.toContain("#")
+  })
+
+  it("captures message, digest, stack, and user agent", () => {
+    const error = Object.assign(new Error("explode"), { digest: "abc123" })
+    error.stack = "Error: explode\n    at fn (foo.ts:1:1)"
+    const ctx = issueReportContextFromError(error, location, ua)
+    expect(ctx.errorMessage).toBe("explode")
+    expect(ctx.errorDigest).toBe("abc123")
+    expect(ctx.errorStack).toContain("at fn (foo.ts:1:1)")
+    expect(ctx.userAgent).toBe("Mozilla/5.0")
+  })
+
+  it("leaves digest undefined when the error has no digest", () => {
+    const ctx = issueReportContextFromError(new Error("plain"), location, ua)
+    expect(ctx.errorDigest).toBeUndefined()
   })
 })

--- a/packages/web/src/libs/issue-report.test.ts
+++ b/packages/web/src/libs/issue-report.test.ts
@@ -56,6 +56,28 @@ describe("buildIssueReportUrl", () => {
     expect(context.length).toBeLessThan(2500)
   })
 
+  it("truncates the stack at a newline boundary with an ellipsis", () => {
+    const stack = `${"abc\n".repeat(700)}finalframe-that-should-be-cut`
+    const url = new URL(buildIssueReportUrl({ errorStack: stack }))
+    const context = url.searchParams.get("additional-context") ?? ""
+    const stackBlock = context.match(/```\n([\s\S]+?)\n```/)?.[1] ?? ""
+    expect(stackBlock).not.toContain("finalframe-that-should-be-cut")
+    expect(stackBlock.endsWith("…")).toBe(true)
+    expect(stackBlock).toMatch(/\nabc\n…$/)
+  })
+
+  it("scrubs Windows-style absolute paths from the stack trace", () => {
+    const stack = [
+      "Error: boom",
+      "    at handler (C:\\Users\\alice\\play14\\foo.ts:12:5)",
+      "    at C:\\Users\\alice\\play14\\bar.ts:99:1",
+    ].join("\n")
+    const url = new URL(buildIssueReportUrl({ errorStack: stack }))
+    const context = url.searchParams.get("additional-context") ?? ""
+    expect(context).not.toContain("C:\\Users")
+    expect(context).toContain("<path>")
+  })
+
   it("joins user agent and stack trace into a single additional-context block", () => {
     const url = new URL(
       buildIssueReportUrl({

--- a/packages/web/src/libs/issue-report.ts
+++ b/packages/web/src/libs/issue-report.ts
@@ -1,6 +1,4 @@
-// Error messages flow verbatim into the public GitHub issue title and body.
-// Keep server-side errors free of PII (email, IP, user input) in `.message`
-// — anything in there will end up pre-filled in the issue form.
+// NOTE: errorMessage and pageUrl flow verbatim into a public GitHub issue — keep them free of PII.
 
 const ISSUE_BASE_URL = "https://github.com/play14team/play14/issues/new"
 const TEMPLATE = "bug_report.yml"

--- a/packages/web/src/libs/issue-report.ts
+++ b/packages/web/src/libs/issue-report.ts
@@ -1,0 +1,51 @@
+const ISSUE_BASE_URL = "https://github.com/play14team/play14/issues/new"
+const TEMPLATE = "bug_report.yml"
+
+const TITLE_MAX = 200
+const STACK_MAX = 2000
+
+export type IssueReportContext = {
+  errorMessage?: string
+  errorDigest?: string
+  errorStack?: string
+  pageUrl?: string
+  userAgent?: string
+}
+
+export function buildIssueReportUrl(ctx: IssueReportContext = {}): string {
+  const params = new URLSearchParams({ template: TEMPLATE })
+
+  if (ctx.errorMessage) {
+    const safeMessage = ctx.errorMessage.replace(/\s+/g, " ").trim()
+    params.set("title", `[Bug]: ${safeMessage}`.slice(0, TITLE_MAX))
+
+    const whatHappened = [
+      "An unexpected error occurred while browsing the website.",
+      "",
+      `**Error message:** ${safeMessage}`,
+      ctx.errorDigest ? `**Error digest:** ${ctx.errorDigest}` : null,
+    ]
+      .filter((line): line is string => line !== null)
+      .join("\n")
+    params.set("what-happened", whatHappened)
+  } else if (ctx.errorDigest) {
+    params.set("title", `[Bug]: error ${ctx.errorDigest}`)
+    params.set("what-happened", `An unexpected error occurred (digest: ${ctx.errorDigest}).`)
+  }
+
+  if (ctx.pageUrl) {
+    params.set("page-url", ctx.pageUrl)
+  }
+
+  const additional: string[] = []
+  if (ctx.userAgent) additional.push(`**User agent:** ${ctx.userAgent}`)
+  if (ctx.errorStack) {
+    const truncated = ctx.errorStack.slice(0, STACK_MAX)
+    additional.push(`**Stack trace:**\n\`\`\`\n${truncated}\n\`\`\``)
+  }
+  if (additional.length > 0) {
+    params.set("additional-context", additional.join("\n\n"))
+  }
+
+  return `${ISSUE_BASE_URL}?${params.toString()}`
+}

--- a/packages/web/src/libs/issue-report.ts
+++ b/packages/web/src/libs/issue-report.ts
@@ -3,6 +3,7 @@ const TEMPLATE = "bug_report.yml"
 
 const TITLE_MAX = 200
 const STACK_MAX = 2000
+const URL_MAX = 8000
 
 export type IssueReportContext = {
   errorMessage?: string
@@ -10,6 +11,15 @@ export type IssueReportContext = {
   errorStack?: string
   pageUrl?: string
   userAgent?: string
+}
+
+function scrubStack(stack: string): string {
+  return stack
+    .split("\n")
+    .map((line) =>
+      line.replace(/\((\/[^)]+)\)/g, "(<path>)").replace(/(^|\s)(\/[^\s)]+)/g, "$1<path>")
+    )
+    .join("\n")
 }
 
 export function buildIssueReportUrl(ctx: IssueReportContext = {}): string {
@@ -40,12 +50,18 @@ export function buildIssueReportUrl(ctx: IssueReportContext = {}): string {
   const additional: string[] = []
   if (ctx.userAgent) additional.push(`**User agent:** ${ctx.userAgent}`)
   if (ctx.errorStack) {
-    const truncated = ctx.errorStack.slice(0, STACK_MAX)
-    additional.push(`**Stack trace:**\n\`\`\`\n${truncated}\n\`\`\``)
+    const scrubbed = scrubStack(ctx.errorStack).slice(0, STACK_MAX)
+    additional.push(`**Stack trace:**\n\`\`\`\n${scrubbed}\n\`\`\``)
   }
   if (additional.length > 0) {
     params.set("additional-context", additional.join("\n\n"))
   }
 
-  return `${ISSUE_BASE_URL}?${params.toString()}`
+  const url = `${ISSUE_BASE_URL}?${params.toString()}`
+  if (url.length <= URL_MAX) return url
+
+  // Drop the verbose section first; if still too long, fall back to a hard slice.
+  params.delete("additional-context")
+  const shorter = `${ISSUE_BASE_URL}?${params.toString()}`
+  return shorter.length <= URL_MAX ? shorter : shorter.slice(0, URL_MAX)
 }

--- a/packages/web/src/libs/issue-report.ts
+++ b/packages/web/src/libs/issue-report.ts
@@ -31,10 +31,10 @@ export function issueReportContextFromError(
   }
 }
 
-// Match absolute filesystem paths anchored at recognisable roots so we don't
-// accidentally scrub URL paths (e.g. `https://host/foo`) — only paths starting
-// at typical Unix roots or with a Windows drive letter are redacted.
-const UNIX_PATH_RE = /\/(?:home|Users|usr|var|tmp|opt|etc|root|app|srv|mnt|runner)\/[^\s'")]+/g
+// Match absolute filesystem paths anywhere they appear. The negative lookbehind
+// for `/` and `:` skips URL hosts (`https://host`) so we don't redact the scheme
+// or its `//`, while still catching every Unix root (`/home`, `/workspace`, …).
+const UNIX_PATH_RE = /(?<![/:])\/[a-zA-Z_][a-zA-Z0-9._-]*(?:\/[^\s'")]*)+/g
 const WINDOWS_PATH_RE = /[A-Za-z]:\\[^\s'")]+/g
 
 function scrubPaths(line: string): string {

--- a/packages/web/src/libs/issue-report.ts
+++ b/packages/web/src/libs/issue-report.ts
@@ -1,3 +1,7 @@
+// Error messages flow verbatim into the public GitHub issue title and body.
+// Keep server-side errors free of PII (email, IP, user input) in `.message`
+// — anything in there will end up pre-filled in the issue form.
+
 const ISSUE_BASE_URL = "https://github.com/play14team/play14/issues/new"
 const TEMPLATE = "bug_report.yml"
 
@@ -17,9 +21,20 @@ function scrubStack(stack: string): string {
   return stack
     .split("\n")
     .map((line) =>
-      line.replace(/\((\/[^)]+)\)/g, "(<path>)").replace(/(^|\s)(\/[^\s)]+)/g, "$1<path>")
+      line
+        .replace(/\((\/[^)]+)\)/g, "(<path>)")
+        .replace(/\(([A-Za-z]:\\[^)]+)\)/g, "(<path>)")
+        .replace(/(^|\s)(\/[^\s)]+)/g, "$1<path>")
+        .replace(/(^|\s)([A-Za-z]:\\[^\s)]+)/g, "$1<path>")
     )
     .join("\n")
+}
+
+function truncateStack(stack: string): string {
+  if (stack.length <= STACK_MAX) return stack
+  const head = stack.slice(0, STACK_MAX)
+  const lastNewline = head.lastIndexOf("\n")
+  return lastNewline > 0 ? `${head.slice(0, lastNewline)}\n…` : `${head}…`
 }
 
 export function buildIssueReportUrl(ctx: IssueReportContext = {}): string {
@@ -50,7 +65,7 @@ export function buildIssueReportUrl(ctx: IssueReportContext = {}): string {
   const additional: string[] = []
   if (ctx.userAgent) additional.push(`**User agent:** ${ctx.userAgent}`)
   if (ctx.errorStack) {
-    const scrubbed = scrubStack(ctx.errorStack).slice(0, STACK_MAX)
+    const scrubbed = truncateStack(scrubStack(ctx.errorStack))
     additional.push(`**Stack trace:**\n\`\`\`\n${scrubbed}\n\`\`\``)
   }
   if (additional.length > 0) {

--- a/packages/web/src/libs/issue-report.ts
+++ b/packages/web/src/libs/issue-report.ts
@@ -34,7 +34,7 @@ export function issueReportContextFromError(
 // Match absolute filesystem paths anchored at recognisable roots so we don't
 // accidentally scrub URL paths (e.g. `https://host/foo`) — only paths starting
 // at typical Unix roots or with a Windows drive letter are redacted.
-const UNIX_PATH_RE = /\/(?:home|Users|usr|var|tmp|opt|etc|root|app|srv|mnt)\/[^\s'")]+/g
+const UNIX_PATH_RE = /\/(?:home|Users|usr|var|tmp|opt|etc|root|app|srv|mnt|runner)\/[^\s'")]+/g
 const WINDOWS_PATH_RE = /[A-Za-z]:\\[^\s'")]+/g
 
 function scrubPaths(line: string): string {

--- a/packages/web/src/libs/issue-report.ts
+++ b/packages/web/src/libs/issue-report.ts
@@ -60,8 +60,10 @@ export function buildIssueReportUrl(ctx: IssueReportContext = {}): string {
   const url = `${ISSUE_BASE_URL}?${params.toString()}`
   if (url.length <= URL_MAX) return url
 
-  // Drop the verbose section first; if still too long, fall back to a hard slice.
+  // Drop the verbose section first; if even that's not enough (e.g. a page URL
+  // longer than ~8 KB), fall back to the bare template so the link stays
+  // navigable rather than slicing inside a percent-encoded sequence.
   params.delete("additional-context")
   const shorter = `${ISSUE_BASE_URL}?${params.toString()}`
-  return shorter.length <= URL_MAX ? shorter : shorter.slice(0, URL_MAX)
+  return shorter.length <= URL_MAX ? shorter : `${ISSUE_BASE_URL}?template=${TEMPLATE}`
 }

--- a/packages/web/src/libs/issue-report.ts
+++ b/packages/web/src/libs/issue-report.ts
@@ -15,17 +15,34 @@ export type IssueReportContext = {
   userAgent?: string
 }
 
+export function issueReportContextFromError(
+  error: Error & { digest?: string },
+  location: Pick<Location, "origin" | "pathname">,
+  ua: Pick<Navigator, "userAgent">
+): IssueReportContext {
+  return {
+    errorMessage: error.message,
+    errorDigest: error.digest,
+    errorStack: error.stack,
+    // Strip query + hash so auth tokens / search terms / IDs in the
+    // current URL don't get pre-filled into the public issue body.
+    pageUrl: `${location.origin}${location.pathname}`,
+    userAgent: ua.userAgent,
+  }
+}
+
+// Match absolute filesystem paths anchored at recognisable roots so we don't
+// accidentally scrub URL paths (e.g. `https://host/foo`) — only paths starting
+// at typical Unix roots or with a Windows drive letter are redacted.
+const UNIX_PATH_RE = /\/(?:home|Users|usr|var|tmp|opt|etc|root|app|srv|mnt)\/[^\s'")]+/g
+const WINDOWS_PATH_RE = /[A-Za-z]:\\[^\s'")]+/g
+
+function scrubPaths(line: string): string {
+  return line.replace(UNIX_PATH_RE, "<path>").replace(WINDOWS_PATH_RE, "<path>")
+}
+
 function scrubStack(stack: string): string {
-  return stack
-    .split("\n")
-    .map((line) =>
-      line
-        .replace(/\((\/[^)]+)\)/g, "(<path>)")
-        .replace(/\(([A-Za-z]:\\[^)]+)\)/g, "(<path>)")
-        .replace(/(^|\s)(\/[^\s)]+)/g, "$1<path>")
-        .replace(/(^|\s)([A-Za-z]:\\[^\s)]+)/g, "$1<path>")
-    )
-    .join("\n")
+  return stack.split("\n").map(scrubPaths).join("\n")
 }
 
 function truncateStack(stack: string): string {
@@ -39,13 +56,17 @@ export function buildIssueReportUrl(ctx: IssueReportContext = {}): string {
   const params = new URLSearchParams({ template: TEMPLATE })
 
   if (ctx.errorMessage) {
-    const safeMessage = ctx.errorMessage.replace(/\s+/g, " ").trim()
-    params.set("title", `[Bug]: ${safeMessage}`.slice(0, TITLE_MAX))
+    // Titles need a single line; bodies can keep newlines so multi-line
+    // messages stay readable. Both get path-scrubbed so server-side paths
+    // never appear in the public issue.
+    const titleMessage = scrubPaths(ctx.errorMessage.replace(/\s+/g, " ").trim())
+    const bodyMessage = scrubPaths(ctx.errorMessage.replace(/[ \t]+/g, " ").trim())
+    params.set("title", `[Bug]: ${titleMessage}`.slice(0, TITLE_MAX))
 
     const whatHappened = [
       "An unexpected error occurred while browsing the website.",
       "",
-      `**Error message:** ${safeMessage}`,
+      `**Error message:** ${bodyMessage}`,
       ctx.errorDigest ? `**Error digest:** ${ctx.errorDigest}` : null,
     ]
       .filter((line): line is string => line !== null)


### PR DESCRIPTION
Adds a GitHub bug-report issue form (.github/ISSUE_TEMPLATE/bug_report.yml)
and a footer link that opens it with the template prefilled, so visitors
can flag website problems from any page. Translations added for all five
next-intl locales.