### PR TITLE
fix(web): surface real Strapi error message instead of generic HTTPError text

### DIFF
--- a/packages/api/database/migrations/2026.05.22T14.00.00.add-up-users-email-lower-unique.js
+++ b/packages/api/database/migrations/2026.05.22T14.00.00.add-up-users-email-lower-unique.js
@@ -1,0 +1,69 @@
+// Enforce a case-insensitive unique constraint on `up_users.email` at the
+// database level. Strapi's users-permissions advanced setting
+// `unique_email: true` only fires inside `providers.connect` (OAuth) and
+// `auth.register` (local password) — direct `documents("plugin::…user").create()`
+// calls bypass it, which lets `import-audience-attendees.ts` and the
+// player-invitation flow in `custom-player.ts` mint a second row with the
+// same email. A functional UNIQUE INDEX on LOWER(email) closes the loophole
+// for every code path, including future ones.
+//
+// Migrations run before Strapi bootstraps, so `strapi.log` isn't available
+// here — `console.log` is the right tool, not a style drift.
+
+const INDEX_NAME = "up_users_email_lower_unique"
+
+async function indexExists(knex) {
+  const row = await knex("pg_indexes")
+    .where({ indexname: INDEX_NAME, schemaname: "public" })
+    .first()
+  return !!row
+}
+
+async function findDuplicateEmails(knex) {
+  return knex("up_users")
+    .select(knex.raw("LOWER(email) AS email"))
+    .count({ count: "*" })
+    .whereNotNull("email")
+    .groupBy(knex.raw("LOWER(email)"))
+    .having(knex.raw("COUNT(*) > 1"))
+}
+
+export async function up(knex) {
+  const hasTable = await knex.schema.hasTable("up_users")
+  if (!hasTable) {
+    console.log("up_users table does not exist yet, skipping (will be created by schema sync)")
+    return
+  }
+
+  if (await indexExists(knex)) {
+    console.log(`Index ${INDEX_NAME} already exists, skipping`)
+    return
+  }
+
+  const duplicates = await findDuplicateEmails(knex)
+  if (duplicates.length > 0) {
+    const sample = duplicates
+      .slice(0, 5)
+      .map((d) => `${d.email} (${d.count} rows)`)
+      .join(", ")
+    throw new Error(
+      `Cannot create unique index ${INDEX_NAME} on up_users(LOWER(email)) — ` +
+        `${duplicates.length} email address(es) currently have duplicate user rows ` +
+        `(sample: ${sample}). Run scripts/cleanup-duplicate-users.ts --apply ` +
+        `first, then re-deploy.`
+    )
+  }
+
+  console.log(`Creating unique index ${INDEX_NAME} on up_users(LOWER(email))`)
+  await knex.raw(`CREATE UNIQUE INDEX ?? ON up_users (LOWER(email))`, [INDEX_NAME])
+}
+
+export async function down(knex) {
+  const hasTable = await knex.schema.hasTable("up_users")
+  if (!hasTable) return
+
+  if (!(await indexExists(knex))) return
+
+  console.log(`Dropping index ${INDEX_NAME}`)
+  await knex.raw(`DROP INDEX ??`, [INDEX_NAME])
+}

--- a/packages/api/database/migrations/2026.05.22T14.00.00.add-up-users-email-lower-unique.js
+++ b/packages/api/database/migrations/2026.05.22T14.00.00.add-up-users-email-lower-unique.js
@@ -9,6 +9,15 @@
 //
 // Migrations run before Strapi bootstraps, so `strapi.log` isn't available
 // here — `console.log` is the right tool, not a style drift.
+//
+// CREATE / DROP INDEX without `CONCURRENTLY` takes an AccessShareLock on
+// `up_users` for the duration. Migrations run pre-traffic on Clever Cloud
+// (during the build/deploy lifecycle, before the new instance accepts
+// requests), so the lock is harmless in the normal path. If you ever need
+// to roll this index back on a live, traffic-serving instance, switch to
+// `CREATE UNIQUE INDEX CONCURRENTLY` / `DROP INDEX CONCURRENTLY` — but
+// those can't run inside a transaction, so they don't compose with Strapi's
+// default migration runner.
 
 const INDEX_NAME = "up_users_email_lower_unique"
 

--- a/packages/api/database/migrations/2026.05.22T14.00.00.add-up-users-email-lower-unique.js
+++ b/packages/api/database/migrations/2026.05.22T14.00.00.add-up-users-email-lower-unique.js
@@ -58,6 +58,9 @@ export async function up(knex) {
   await knex.raw(`CREATE UNIQUE INDEX ?? ON up_users (LOWER(email))`, [INDEX_NAME])
 }
 
+// `down` is index-only — it does NOT rehydrate the user rows that
+// scripts/cleanup-duplicate-users.ts may have deleted before `up` ran. If
+// you need the pre-cleanup state back, restore from a database backup.
 export async function down(knex) {
   const hasTable = await knex.schema.hasTable("up_users")
   if (!hasTable) return

--- a/packages/api/providers/strapi-provider-email-sender/src/index.js
+++ b/packages/api/providers/strapi-provider-email-sender/src/index.js
@@ -41,14 +41,35 @@ function parseEmailAddress(address) {
 }
 
 /**
- * Normalize a recipient value (string | string[]) into the shape Sender.net expects.
- * A plain string maps to a single `{ email }` object; an array maps to `[{ email }, ...]`.
+ * Normalize a recipient value (string | string[] | object | object[]) into the
+ * shape Sender.net's `/v2/message/send` endpoint accepts for `to` / `reply_to`.
+ *
+ * Sender.net validates each recipient as either:
+ *   - a plain email string (`"alice@example.com"`), or
+ *   - an `{ email, name }` object — BOTH keys must be present.
+ *
+ * The `{ email }` shape we used previously is silently tolerated for the
+ * single-object form but rejected with HTTP 422
+ *   { "message": "email address must be either email string or
+ *                 {email, name} object", "type": "validation" }
+ * as soon as `to` is an array (e.g. multi-admin claim notifications). To stay
+ * inside the accepted set in every case we coerce each address to a plain
+ * email string here; the brand/sender name still travels via the `from`
+ * field which always carries `{ email, name }`.
  */
+function toRecipient(value) {
+  if (typeof value === "string") return value
+  if (value && typeof value === "object" && typeof value.email === "string") {
+    return value.email
+  }
+  return value
+}
+
 function toRecipients(value) {
   if (Array.isArray(value)) {
-    return value.map((addr) => ({ email: addr }))
+    return value.map(toRecipient)
   }
-  return { email: value }
+  return toRecipient(value)
 }
 
 /**

--- a/packages/api/providers/strapi-provider-email-sender/src/index.js
+++ b/packages/api/providers/strapi-provider-email-sender/src/index.js
@@ -62,7 +62,14 @@ function toRecipient(value) {
   if (value && typeof value === "object" && typeof value.email === "string") {
     return value.email
   }
-  return value
+  // Don't silently pass through — null/undefined/numbers would still reach
+  // Sender.net and trip a 422 with no breadcrumb. Throw at the boundary so
+  // the caller's stack trace points at the bad input.
+  throw new TypeError(
+    `Invalid Sender.net recipient: expected a string or { email } object, got ${
+      value === null ? "null" : typeof value
+    }`
+  )
 }
 
 function toRecipients(value) {

--- a/packages/api/scripts/cleanup-duplicate-users.ts
+++ b/packages/api/scripts/cleanup-duplicate-users.ts
@@ -117,6 +117,11 @@ async function reassignClaims(strapi: any, fromUserId: number, toUserId: number)
 
   for (const claim of claims) {
     if (APPLY) {
+      // `data: { user: <int> }` is the documented relation-SET shape for
+      // updates (different from filters, where `{ user: <int> }` is
+      // ambiguous — there we use `{ user: { id: <int> } }`). The pattern
+      // matches every other relation update in this codebase, e.g.
+      // `custom-player.ts:1443` does `data: { player: targetPlayer.id }`.
       await strapi.documents("api::player-claim.player-claim").update({
         documentId: claim.documentId,
         data: { user: toUserId } as any,
@@ -137,14 +142,22 @@ async function moveOrphanPlayerLink(
     // canonical. Without a transaction, a failure between the two updates
     // would leave the canonical with no player link AND the duplicate
     // already cleared — losing the player's `user` relation entirely.
+    //
+    // Use `strapi.db.query()` (Query Engine API) rather than the Document
+    // Service inside the transaction. The Query Engine is the layer that
+    // Strapi's own transaction wrapper participates in directly; Strapi 5
+    // does not contractually guarantee that `strapi.documents()` calls
+    // inherit the ambient transaction context. CLAUDE.md prefers the
+    // Document Service, but a one-off script doing a critical atomic
+    // re-link is the right place to bend that rule.
     await strapi.db.transaction(async () => {
-      await strapi.documents("plugin::users-permissions.user").update({
-        documentId: duplicate.documentId,
-        data: { player: null } as any,
+      await strapi.db.query("plugin::users-permissions.user").update({
+        where: { id: duplicate.id },
+        data: { player: null },
       })
-      await strapi.documents("plugin::users-permissions.user").update({
-        documentId: canonical.documentId,
-        data: { player: duplicate.player!.id } as any,
+      await strapi.db.query("plugin::users-permissions.user").update({
+        where: { id: canonical.id },
+        data: { player: duplicate.player!.id },
       })
     })
   }

--- a/packages/api/scripts/cleanup-duplicate-users.ts
+++ b/packages/api/scripts/cleanup-duplicate-users.ts
@@ -155,6 +155,17 @@ async function main() {
       }
 
       for (const dup of duplicates) {
+        // If both rows already point at DIFFERENT players, deleting the
+        // duplicate would silently orphan its player. Bail loudly so the
+        // operator can resolve the conflict manually (typically: merge the
+        // two players first via the admin UI, then re-run this script).
+        if (dup.player?.id && canonical.player?.id && dup.player.id !== canonical.player.id) {
+          console.error(
+            `    ✗ SKIPPING duplicate id=${dup.id}: it points at player "${dup.player.name}" but canonical id=${canonical.id} points at "${canonical.player.name}". Resolve the player conflict first, then re-run.`
+          )
+          continue
+        }
+
         const moved = await moveOrphanPlayerLink(strapi, dup, canonical)
         if (moved) {
           totalPlayerLinksMoved++

--- a/packages/api/scripts/cleanup-duplicate-users.ts
+++ b/packages/api/scripts/cleanup-duplicate-users.ts
@@ -18,6 +18,12 @@
  *
  * Default mode is dry-run — pass `--apply` to actually mutate.
  *
+ * Side-effects: the user delete goes through the Document Service, so any
+ * Strapi lifecycle hook registered on `plugin::users-permissions.user`
+ * (none today, but a future extension could add one) WILL fire for every
+ * deleted row. If you wire one up, audit it before running with `--apply`
+ * or temporarily disable noisy notifications.
+ *
  * Usage:
  *   bun --filter play14-api strapi script scripts/cleanup-duplicate-users.ts
  *   bun --filter play14-api strapi script scripts/cleanup-duplicate-users.ts -- --apply
@@ -225,9 +231,10 @@ async function main() {
 
     console.log("\n[cleanup] Summary")
     console.log(`  Duplicate email groups:    ${totalGroups}`)
-    console.log(`  Duplicate users removed:   ${totalDuplicatesRemoved}`)
-    console.log(`  Player-claim rows moved:   ${totalClaimsReassigned}`)
-    console.log(`  Player links re-pointed:   ${totalPlayerLinksMoved}`)
+    const verb = APPLY ? "" : "would be "
+    console.log(`  Duplicate users ${verb}removed:   ${totalDuplicatesRemoved}`)
+    console.log(`  Player-claim rows ${verb}moved:   ${totalClaimsReassigned}`)
+    console.log(`  Player links ${verb}re-pointed:   ${totalPlayerLinksMoved}`)
     if (!APPLY) {
       console.log("\n[cleanup] Re-run with --apply to actually mutate.")
     }

--- a/packages/api/scripts/cleanup-duplicate-users.ts
+++ b/packages/api/scripts/cleanup-duplicate-users.ts
@@ -42,15 +42,31 @@ interface DuplicateGroup {
   users: UserRow[]
 }
 
+const PAGE_SIZE = 500
+
+async function findAllUsers(strapi: any): Promise<UserRow[]> {
+  // Strapi 5's Document Service doesn't document `limit: -1` as "unbounded"
+  // — different content-types interpret it differently and some clamp to
+  // the default page size. Paginate explicitly so we always read every row.
+  const all: UserRow[] = []
+  let start = 0
+  while (true) {
+    const page = (await strapi.documents("plugin::users-permissions.user").findMany({
+      fields: ["id", "documentId", "username", "email", "provider", "createdAt"],
+      populate: { player: { fields: ["id", "documentId", "name"] } },
+      sort: { createdAt: "asc" },
+      start,
+      limit: PAGE_SIZE,
+    })) as UserRow[]
+    all.push(...page)
+    if (page.length < PAGE_SIZE) break
+    start += PAGE_SIZE
+  }
+  return all
+}
+
 async function findDuplicateGroups(strapi: any): Promise<DuplicateGroup[]> {
-  // Group by lower(email). The Document Service has no GROUP BY, so we list
-  // everything and group in memory — fine for a one-off on a small users table.
-  const users = (await strapi.documents("plugin::users-permissions.user").findMany({
-    fields: ["id", "documentId", "username", "email", "provider", "createdAt"],
-    populate: { player: { fields: ["id", "documentId", "name"] } },
-    sort: { createdAt: "asc" },
-    limit: -1,
-  })) as UserRow[]
+  const users = await findAllUsers(strapi)
 
   const byEmail = new Map<string, UserRow[]>()
   for (const u of users) {
@@ -75,11 +91,23 @@ function pickCanonical(group: UserRow[]): UserRow {
 }
 
 async function reassignClaims(strapi: any, fromUserId: number, toUserId: number): Promise<number> {
-  const claims = (await strapi.documents("api::player-claim.player-claim").findMany({
-    filters: { user: fromUserId },
-    fields: ["id", "documentId"],
-    limit: -1,
-  })) as Array<{ id: number; documentId: string }>
+  // Filter by the relation's `id`, not the raw integer. Strapi 5's Document
+  // Service treats `{ user: <int> }` as ambiguous and may silently match
+  // nothing instead of throwing — `{ user: { id: <int> } }` is the
+  // documented shape.
+  const claims: Array<{ id: number; documentId: string }> = []
+  let start = 0
+  while (true) {
+    const page = (await strapi.documents("api::player-claim.player-claim").findMany({
+      filters: { user: { id: fromUserId } } as any,
+      fields: ["id", "documentId"],
+      start,
+      limit: PAGE_SIZE,
+    })) as Array<{ id: number; documentId: string }>
+    claims.push(...page)
+    if (page.length < PAGE_SIZE) break
+    start += PAGE_SIZE
+  }
 
   for (const claim of claims) {
     if (APPLY) {
@@ -99,14 +127,19 @@ async function moveOrphanPlayerLink(
 ): Promise<boolean> {
   if (!duplicate.player?.id || canonical.player?.id) return false
   if (APPLY) {
-    // Unlink first to free the oneToOne, then link to canonical.
-    await strapi.documents("plugin::users-permissions.user").update({
-      documentId: duplicate.documentId,
-      data: { player: null } as any,
-    })
-    await strapi.documents("plugin::users-permissions.user").update({
-      documentId: canonical.documentId,
-      data: { player: duplicate.player.id } as any,
+    // Atomically detach the player from the duplicate and reattach to the
+    // canonical. Without a transaction, a failure between the two updates
+    // would leave the canonical with no player link AND the duplicate
+    // already cleared — losing the player's `user` relation entirely.
+    await strapi.db.transaction(async () => {
+      await strapi.documents("plugin::users-permissions.user").update({
+        documentId: duplicate.documentId,
+        data: { player: null } as any,
+      })
+      await strapi.documents("plugin::users-permissions.user").update({
+        documentId: canonical.documentId,
+        data: { player: duplicate.player!.id } as any,
+      })
     })
   }
   return true

--- a/packages/api/scripts/cleanup-duplicate-users.ts
+++ b/packages/api/scripts/cleanup-duplicate-users.ts
@@ -1,0 +1,198 @@
+/**
+ * One-off cleanup for users-permissions rows that share the same email.
+ *
+ * The OAuth wrapper in `src/extensions/users-permissions/strapi-server.ts`
+ * proactively dedupes by email going forward, but historical duplicates can
+ * leave a player linked to one user while a pending claim sits on another —
+ * making `PUT /admin/player-claims/:id/approve` fail with
+ * "This player is already linked to another user".
+ *
+ * For each email with >1 user row, the script:
+ *   1. Picks a canonical user — prefers the one linked to a `player`, else the
+ *      one with the oldest `createdAt`.
+ *   2. Reassigns `player-claim.user` rows from the duplicates to the canonical.
+ *   3. If any duplicate has a `player` link that the canonical lacks, moves
+ *      the link to the canonical (and unlinks it from the duplicate first to
+ *      satisfy the oneToOne constraint).
+ *   4. Deletes the duplicate user rows.
+ *
+ * Default mode is dry-run — pass `--apply` to actually mutate.
+ *
+ * Usage:
+ *   bun --filter play14-api strapi script scripts/cleanup-duplicate-users.ts
+ *   bun --filter play14-api strapi script scripts/cleanup-duplicate-users.ts -- --apply
+ */
+
+import { compileStrapi, createStrapi } from "@strapi/strapi"
+
+const APPLY = process.argv.includes("--apply")
+
+interface UserRow {
+  id: number
+  documentId: string
+  username: string
+  email: string
+  provider: string
+  createdAt: string
+  player?: { id: number; documentId: string; name: string } | null
+}
+
+interface DuplicateGroup {
+  email: string
+  users: UserRow[]
+}
+
+async function findDuplicateGroups(strapi: any): Promise<DuplicateGroup[]> {
+  // Group by lower(email). The Document Service has no GROUP BY, so we list
+  // everything and group in memory — fine for a one-off on a small users table.
+  const users = (await strapi.documents("plugin::users-permissions.user").findMany({
+    fields: ["id", "documentId", "username", "email", "provider", "createdAt"],
+    populate: { player: { fields: ["id", "documentId", "name"] } },
+    sort: { createdAt: "asc" },
+    limit: -1,
+  })) as UserRow[]
+
+  const byEmail = new Map<string, UserRow[]>()
+  for (const u of users) {
+    if (!u.email) continue
+    const key = u.email.toLowerCase()
+    const bucket = byEmail.get(key) ?? []
+    bucket.push(u)
+    byEmail.set(key, bucket)
+  }
+
+  return Array.from(byEmail.entries())
+    .filter(([, group]) => group.length > 1)
+    .map(([email, group]) => ({ email, users: group }))
+}
+
+function pickCanonical(group: UserRow[]): UserRow {
+  // Prefer a user that is already linked to a player.
+  const linked = group.find((u) => u.player?.id)
+  if (linked) return linked
+  // Otherwise, the oldest user (already sorted asc by createdAt).
+  return group[0]
+}
+
+async function reassignClaims(strapi: any, fromUserId: number, toUserId: number): Promise<number> {
+  const claims = (await strapi.documents("api::player-claim.player-claim").findMany({
+    filters: { user: fromUserId },
+    fields: ["id", "documentId"],
+    limit: -1,
+  })) as Array<{ id: number; documentId: string }>
+
+  for (const claim of claims) {
+    if (APPLY) {
+      await strapi.documents("api::player-claim.player-claim").update({
+        documentId: claim.documentId,
+        data: { user: toUserId } as any,
+      })
+    }
+  }
+  return claims.length
+}
+
+async function moveOrphanPlayerLink(
+  strapi: any,
+  duplicate: UserRow,
+  canonical: UserRow
+): Promise<boolean> {
+  if (!duplicate.player?.id || canonical.player?.id) return false
+  if (APPLY) {
+    // Unlink first to free the oneToOne, then link to canonical.
+    await strapi.documents("plugin::users-permissions.user").update({
+      documentId: duplicate.documentId,
+      data: { player: null } as any,
+    })
+    await strapi.documents("plugin::users-permissions.user").update({
+      documentId: canonical.documentId,
+      data: { player: duplicate.player.id } as any,
+    })
+  }
+  return true
+}
+
+async function deleteUser(strapi: any, user: UserRow): Promise<void> {
+  if (APPLY) {
+    await strapi.documents("plugin::users-permissions.user").delete({
+      documentId: user.documentId,
+    })
+  }
+}
+
+async function main() {
+  console.log(`[cleanup] Mode: ${APPLY ? "APPLY (mutating)" : "DRY-RUN"}`)
+  const { appDir, distDir } = await compileStrapi()
+  const strapi = await createStrapi({ appDir, distDir }).load()
+
+  let totalGroups = 0
+  let totalDuplicatesRemoved = 0
+  let totalClaimsReassigned = 0
+  let totalPlayerLinksMoved = 0
+
+  try {
+    const groups = await findDuplicateGroups(strapi)
+    if (groups.length === 0) {
+      console.log("[cleanup] No duplicate-email users found. Nothing to do.")
+      return
+    }
+
+    console.log(`[cleanup] Found ${groups.length} email(s) with duplicate users:\n`)
+
+    for (const group of groups) {
+      totalGroups++
+      const canonical = pickCanonical(group.users)
+      const duplicates = group.users.filter((u) => u.id !== canonical.id)
+
+      console.log(`\n  Email: ${group.email}`)
+      console.log(
+        `  Canonical: id=${canonical.id} username=${canonical.username} provider=${canonical.provider} createdAt=${canonical.createdAt} player=${canonical.player?.name ?? "—"}`
+      )
+      for (const dup of duplicates) {
+        console.log(
+          `  Duplicate: id=${dup.id} username=${dup.username} provider=${dup.provider} createdAt=${dup.createdAt} player=${dup.player?.name ?? "—"}`
+        )
+      }
+
+      for (const dup of duplicates) {
+        const moved = await moveOrphanPlayerLink(strapi, dup, canonical)
+        if (moved) {
+          totalPlayerLinksMoved++
+          // Update local view so subsequent iterations see the new state.
+          canonical.player = dup.player
+          console.log(
+            `    → ${APPLY ? "moved" : "would move"} player link "${dup.player?.name}" from user ${dup.id} to canonical ${canonical.id}`
+          )
+        }
+
+        const reassigned = await reassignClaims(strapi, dup.id, canonical.id)
+        totalClaimsReassigned += reassigned
+        if (reassigned > 0) {
+          console.log(
+            `    → ${APPLY ? "reassigned" : "would reassign"} ${reassigned} player-claim row(s) from user ${dup.id} to canonical ${canonical.id}`
+          )
+        }
+
+        await deleteUser(strapi, dup)
+        totalDuplicatesRemoved++
+        console.log(`    → ${APPLY ? "deleted" : "would delete"} duplicate user id=${dup.id}`)
+      }
+    }
+
+    console.log("\n[cleanup] Summary")
+    console.log(`  Duplicate email groups:    ${totalGroups}`)
+    console.log(`  Duplicate users removed:   ${totalDuplicatesRemoved}`)
+    console.log(`  Player-claim rows moved:   ${totalClaimsReassigned}`)
+    console.log(`  Player links re-pointed:   ${totalPlayerLinksMoved}`)
+    if (!APPLY) {
+      console.log("\n[cleanup] Re-run with --apply to actually mutate.")
+    }
+  } finally {
+    await strapi.destroy()
+  }
+}
+
+main().catch((err) => {
+  console.error("[cleanup] Failed:", err)
+  process.exit(1)
+})

--- a/packages/api/scripts/test-emails-simple.ts
+++ b/packages/api/scripts/test-emails-simple.ts
@@ -292,7 +292,7 @@ async function sendTestEmails() {
         },
         body: JSON.stringify({
           from: parseFromEmail(FROM_EMAIL),
-          to: { email: TEST_EMAIL },
+          to: TEST_EMAIL,
           subject: `${subjectPrefix} ${subject}`,
           html,
           text,

--- a/packages/api/src/api/player/controllers/custom-player.ts
+++ b/packages/api/src/api/player/controllers/custom-player.ts
@@ -14,6 +14,7 @@ import { isValidEmail, isValidUrl } from "../../../libs/validation"
 import { sendEmail } from "../../../services/email-send"
 import { addSubscriberToGroup } from "../../../services/sender-subscribers"
 import { syncUserRoleFromPlayer } from "../../../services/user-role-sync"
+import { findUserByEmail } from "../../../services/users-permissions/find-user-by-email"
 
 /**
  * Get or create a folder in the media library by name
@@ -1406,49 +1407,79 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
 
         targetUser = fullUser
       } else {
-        // Create a new user and link to player
-        // Generate username from player name (firstname.lastname format)
-        const username = nameToUsername(targetPlayer.name)
+        // Reuse any existing user with this email (case-insensitive) instead
+        // of minting a duplicate. Direct `documents().create()` bypasses the
+        // users-permissions `unique_email` setting, and the LOWER(email)
+        // UNIQUE INDEX would otherwise throw on insert.
+        const existing = (await findUserByEmail(strapi, email, { player: true })) as {
+          id: number
+          documentId: string
+          blocked?: boolean
+          player?: { id?: number; documentId?: string } | null
+        } | null
 
-        // Map player position to role type
-        const positionToRoleType: Record<string, string> = {
-          Founder: "founder",
-          Mentor: "mentor",
-          Host: "host",
-          Player: "player",
-        }
-        const roleType = positionToRoleType[targetPlayer.position] || "player"
-
-        // Get the role matching the player's position
-        const userRole = await strapi.db.query("plugin::users-permissions.role").findOne({
-          where: { type: roleType },
-        })
-
-        if (!userRole) {
-          strapi.log.error(
-            `[Player] Role '${roleType}' not found for position '${targetPlayer.position}'`
+        if (existing) {
+          if (existing.blocked) {
+            return ctx.badRequest("This user is blocked and cannot receive invitations")
+          }
+          if (existing.player?.id && existing.player.id !== targetPlayer.id) {
+            return ctx.badRequest(`Email ${email} is already linked to a different player profile`)
+          }
+          if (!existing.player?.id) {
+            await strapi.documents("plugin::users-permissions.user").update({
+              documentId: existing.documentId,
+              data: { player: targetPlayer.id } as any,
+            })
+          }
+          targetUser = existing
+          strapi.log.info(
+            `[Player] Reusing existing user ${existing.documentId} for ${email} (was about to create a duplicate)`
           )
-          return ctx.internalServerError("Failed to create user")
+        } else {
+          // Create a new user and link to player
+          // Generate username from player name (firstname.lastname format)
+          const username = nameToUsername(targetPlayer.name)
+
+          // Map player position to role type
+          const positionToRoleType: Record<string, string> = {
+            Founder: "founder",
+            Mentor: "mentor",
+            Host: "host",
+            Player: "player",
+          }
+          const roleType = positionToRoleType[targetPlayer.position] || "player"
+
+          // Get the role matching the player's position
+          const userRole = await strapi.db.query("plugin::users-permissions.role").findOne({
+            where: { type: roleType },
+          })
+
+          if (!userRole) {
+            strapi.log.error(
+              `[Player] Role '${roleType}' not found for position '${targetPlayer.position}'`
+            )
+            return ctx.internalServerError("Failed to create user")
+          }
+
+          // Create user
+          const newUser = await strapi.documents("plugin::users-permissions.user").create({
+            data: {
+              username,
+              email: email.toLowerCase(),
+              password: randomBytes(32).toString("hex"), // Random password, will be reset
+              confirmed: true, // Pre-confirm since we're sending invite
+              blocked: false,
+              role: userRole.id,
+              player: targetPlayer.id,
+              invitationStatus: "pending",
+            } as any,
+          })
+
+          targetUser = newUser
+          strapi.log.info(
+            `[Player] Created new user ${newUser.documentId} with role '${roleType}' for player ${targetPlayer.name}`
+          )
         }
-
-        // Create user
-        const newUser = await strapi.documents("plugin::users-permissions.user").create({
-          data: {
-            username,
-            email: email.toLowerCase(),
-            password: randomBytes(32).toString("hex"), // Random password, will be reset
-            confirmed: true, // Pre-confirm since we're sending invite
-            blocked: false,
-            role: userRole.id,
-            player: targetPlayer.id,
-            invitationStatus: "pending",
-          } as any,
-        })
-
-        targetUser = newUser
-        strapi.log.info(
-          `[Player] Created new user ${newUser.documentId} with role '${roleType}' for player ${targetPlayer.name}`
-        )
       }
 
       // Generate reset token and send invite

--- a/packages/api/src/extensions/users-permissions/strapi-server.ts
+++ b/packages/api/src/extensions/users-permissions/strapi-server.ts
@@ -266,8 +266,12 @@ export default (plugin: StrapiPlugin) => {
       email: string,
       provider: string
     ): Promise<UserRecord | null> => {
+      // Case-insensitive equality — the email is already lowercased by
+      // resolveProfileEmail, so `$eqi` is effectively a no-op for matching,
+      // but it documents intent and stays in sync with `findUserByEmail`
+      // (the only other email-lookup helper in the codebase).
       const existing = (await strapi.documents("plugin::users-permissions.user").findFirst({
-        filters: { email },
+        filters: { email: { $eqi: email } } as any,
         populate: { role: true, player: true } as any,
         sort: { createdAt: "asc" },
       })) as (UserRecord & { confirmed?: boolean }) | null

--- a/packages/api/src/extensions/users-permissions/strapi-server.ts
+++ b/packages/api/src/extensions/users-permissions/strapi-server.ts
@@ -265,6 +265,15 @@ export default (plugin: StrapiPlugin) => {
     // a previous user was created by a non-OAuth code path (player auto-link,
     // CSV import, etc.).
     //
+    // Side effect of bypassing `originalConnect`: the matching user's
+    // `provider`, `access_token`, `refresh_token`, and `expires_in` fields
+    // stay frozen at whatever was written on the original signup. For our
+    // current use-case (we never call provider APIs on behalf of the user;
+    // OAuth is purely for authentication) this is fine. If we ever need a
+    // live access token (e.g. to read a Google Calendar), revisit this:
+    // either re-run the upstream token-update logic after the merge, or
+    // refactor to patch `originalConnect` rather than short-circuiting it.
+    //
     // Security: only an `confirmed: true` user is merged. An unconfirmed local
     // row is never silently bound to an OAuth login — that would let an
     // attacker take over an account by registering its email at any IdP that
@@ -297,7 +306,9 @@ export default (plugin: StrapiPlugin) => {
         return null
       }
       strapi.log.info(
-        `[OAuth] User ${email} logged in via ${provider}, reusing existing account (original provider: ${existing.provider})`
+        `[OAuth] User ${email} logged in via ${provider}, reusing existing account ` +
+          `(original provider: ${existing.provider}; access/refresh tokens were NOT ` +
+          `refreshed because originalConnect was bypassed — see strapi-server.ts comment)`
       )
       return existing
     }

--- a/packages/api/src/extensions/users-permissions/strapi-server.ts
+++ b/packages/api/src/extensions/users-permissions/strapi-server.ts
@@ -219,12 +219,22 @@ export default (plugin: StrapiPlugin) => {
     const service = originalProvidersFactory.apply(this, args as [])
     const originalConnect = service.connect.bind(service)
 
-    // Resolve the OAuth profile email once per login and reuse it on every
-    // subsequent branch (proactive lookup, reactive safety net). Many OAuth
-    // providers (Google, GitHub, Discord) reject re-use of the `access_token`
-    // for a second profile fetch, and even where they don't it costs a round-
-    // trip per login. Returns null on any failure so the upstream connect path
-    // remains the default behaviour.
+    // Resolve the OAuth profile email so we can look up an existing user
+    // BEFORE calling `originalConnect`. We cache the result in `profileEmail`
+    // and reuse it in the safety-net catch instead of fetching the profile a
+    // second time there.
+    //
+    // Trade-off — there are still TWO profile fetches per first-time login
+    // (one here, one inside `originalConnect`), because `originalConnect` is
+    // a plugin black box that always re-fetches internally. We accept that
+    // because every OAuth provider currently wired up in this project
+    // (Google, GitHub, Microsoft, LinkedIn) issues access tokens that can be
+    // re-presented to the user-info endpoint until they expire — they're not
+    // single-use. If a future provider is added with single-use access tokens
+    // (e.g. some PKCE-only flows), this assumption breaks and the second
+    // fetch inside `originalConnect` will fail with a token error that this
+    // catch does NOT swallow. In that case either drop the proactive fetch
+    // for that provider or patch `originalConnect` directly.
     const resolveProfileEmail = async (
       provider: string,
       query: Record<string, unknown>
@@ -239,7 +249,11 @@ export default (plugin: StrapiPlugin) => {
         })
         return typeof profile?.email === "string" ? profile.email.toLowerCase() : null
       } catch (error) {
-        strapi.log.warn(`[OAuth] Profile email resolution failed: ${error}`)
+        const errName = error instanceof Error ? error.name : typeof error
+        const errMsg = error instanceof Error ? error.message : String(error)
+        strapi.log.warn(
+          `[OAuth] Profile email resolution failed for provider=${provider}: ${errName}: ${errMsg}`
+        )
         return null
       }
     }

--- a/packages/api/src/extensions/users-permissions/strapi-server.ts
+++ b/packages/api/src/extensions/users-permissions/strapi-server.ts
@@ -219,52 +219,94 @@ export default (plugin: StrapiPlugin) => {
     const service = originalProvidersFactory.apply(this, args as [])
     const originalConnect = service.connect.bind(service)
 
+    // Proactive dedupe: look up an existing user by the OAuth profile email
+    // BEFORE delegating to the upstream `connect`. This guards against duplicate
+    // user rows even when the users-permissions `unique_email` setting is not
+    // enforced in the live core store (config drift), or when a previous user
+    // was created by a non-OAuth code path (player auto-link, CSV import, etc.).
+    //
+    // Returns null on any failure (network blip, missing email, etc.) so the
+    // upstream path remains the default behaviour.
+    const lookupExistingByEmail = async (
+      provider: string,
+      query: Record<string, unknown>
+    ): Promise<UserRecord | null> => {
+      try {
+        const providersRegistry = strapi.plugin("users-permissions").service("providers-registry")
+        const profile = await providersRegistry.run({
+          provider,
+          accessToken: query.access_token,
+          query,
+          providers: providersRegistry.getAll(),
+        })
+        const email = typeof profile?.email === "string" ? profile.email.toLowerCase() : null
+        if (!email) return null
+        const existing = (await strapi.documents("plugin::users-permissions.user").findFirst({
+          filters: { email },
+          populate: { role: true },
+        })) as UserRecord | null
+        if (existing) {
+          strapi.log.info(
+            `[OAuth] User ${email} logged in via ${provider}, reusing existing account (original provider: ${existing.provider})`
+          )
+        }
+        return existing
+      } catch (error) {
+        strapi.log.warn(`[OAuth] Pre-connect email lookup failed: ${error}`)
+        return null
+      }
+    }
+
     // Wrap the connect method
     service.connect = async (
       provider: string,
       query: Record<string, unknown>
     ): Promise<UserRecord> => {
-      let user: UserRecord
+      // Try the proactive path first so we never create a duplicate row.
+      let user: UserRecord | null = await lookupExistingByEmail(provider, query)
 
-      try {
-        // Try the original connect
-        user = await originalConnect(provider, query)
-      } catch (error: unknown) {
-        const err = error as { message?: string }
-        // Check if error is "Email is already taken"
-        if (err.message?.includes("Email is already taken")) {
-          // Get user profile from the OAuth provider to find the email
-          const providersRegistry = strapi.plugin("users-permissions").service("providers-registry")
+      if (!user) {
+        try {
+          user = await originalConnect(provider, query)
+        } catch (error: unknown) {
+          const err = error as { message?: string }
+          // Reactive safety net for the narrow race window where a duplicate
+          // gets created between the lookup and originalConnect.
+          if (err.message?.includes("Email is already taken")) {
+            const providersRegistry = strapi
+              .plugin("users-permissions")
+              .service("providers-registry")
 
-          const profile = await providersRegistry.run({
-            provider,
-            accessToken: query.access_token,
-            query,
-            providers: providersRegistry.getAll(),
-          })
+            const profile = await providersRegistry.run({
+              provider,
+              accessToken: query.access_token,
+              query,
+              providers: providersRegistry.getAll(),
+            })
 
-          if (profile?.email) {
-            const email = profile.email.toLowerCase()
-            const existingUser = (await strapi
-              .documents("plugin::users-permissions.user")
-              .findFirst({
-                filters: { email },
-                populate: { role: true },
-              })) as UserRecord | null
+            if (profile?.email) {
+              const email = profile.email.toLowerCase()
+              const existingUser = (await strapi
+                .documents("plugin::users-permissions.user")
+                .findFirst({
+                  filters: { email },
+                  populate: { role: true },
+                })) as UserRecord | null
 
-            if (existingUser) {
-              strapi.log.info(
-                `[OAuth] User ${email} logged in via ${provider}, using existing account (original provider: ${existingUser.provider})`
-              )
-              user = existingUser
+              if (existingUser) {
+                strapi.log.info(
+                  `[OAuth] User ${email} logged in via ${provider}, using existing account (original provider: ${existingUser.provider})`
+                )
+                user = existingUser
+              } else {
+                throw error
+              }
             } else {
               throw error
             }
           } else {
             throw error
           }
-        } else {
-          throw error
         }
       }
 

--- a/packages/api/src/extensions/users-permissions/strapi-server.ts
+++ b/packages/api/src/extensions/users-permissions/strapi-server.ts
@@ -219,18 +219,16 @@ export default (plugin: StrapiPlugin) => {
     const service = originalProvidersFactory.apply(this, args as [])
     const originalConnect = service.connect.bind(service)
 
-    // Proactive dedupe: look up an existing user by the OAuth profile email
-    // BEFORE delegating to the upstream `connect`. This guards against duplicate
-    // user rows even when the users-permissions `unique_email` setting is not
-    // enforced in the live core store (config drift), or when a previous user
-    // was created by a non-OAuth code path (player auto-link, CSV import, etc.).
-    //
-    // Returns null on any failure (network blip, missing email, etc.) so the
-    // upstream path remains the default behaviour.
-    const lookupExistingByEmail = async (
+    // Resolve the OAuth profile email once per login and reuse it on every
+    // subsequent branch (proactive lookup, reactive safety net). Many OAuth
+    // providers (Google, GitHub, Discord) reject re-use of the `access_token`
+    // for a second profile fetch, and even where they don't it costs a round-
+    // trip per login. Returns null on any failure so the upstream connect path
+    // remains the default behaviour.
+    const resolveProfileEmail = async (
       provider: string,
       query: Record<string, unknown>
-    ): Promise<UserRecord | null> => {
+    ): Promise<string | null> => {
       try {
         const providersRegistry = strapi.plugin("users-permissions").service("providers-registry")
         const profile = await providersRegistry.run({
@@ -239,22 +237,51 @@ export default (plugin: StrapiPlugin) => {
           query,
           providers: providersRegistry.getAll(),
         })
-        const email = typeof profile?.email === "string" ? profile.email.toLowerCase() : null
-        if (!email) return null
-        const existing = (await strapi.documents("plugin::users-permissions.user").findFirst({
-          filters: { email },
-          populate: { role: true },
-        })) as UserRecord | null
-        if (existing) {
-          strapi.log.info(
-            `[OAuth] User ${email} logged in via ${provider}, reusing existing account (original provider: ${existing.provider})`
-          )
-        }
-        return existing
+        return typeof profile?.email === "string" ? profile.email.toLowerCase() : null
       } catch (error) {
-        strapi.log.warn(`[OAuth] Pre-connect email lookup failed: ${error}`)
+        strapi.log.warn(`[OAuth] Profile email resolution failed: ${error}`)
         return null
       }
+    }
+
+    // Proactive dedupe: look up an existing user by the OAuth profile email
+    // BEFORE delegating to the upstream `connect`. This guards against
+    // duplicate user rows even when the users-permissions `unique_email`
+    // setting is not enforced in the live core store (config drift), or when
+    // a previous user was created by a non-OAuth code path (player auto-link,
+    // CSV import, etc.).
+    //
+    // Security: only an `confirmed: true` user is merged. An unconfirmed local
+    // row is never silently bound to an OAuth login — that would let an
+    // attacker take over an account by registering its email at any IdP that
+    // happens to issue it. If `originalConnect` then runs and Strapi's own
+    // checks reject the unconfirmed row, the operator gets a meaningful error;
+    // they don't get a silent merge.
+    //
+    // `findFirst` sorted by `createdAt` ascending picks the oldest matching
+    // user — matches `pickCanonical()` in scripts/cleanup-duplicate-users.ts
+    // so the OAuth wrapper and the cleanup never disagree on which row is
+    // canonical.
+    const lookupExistingByEmail = async (
+      email: string,
+      provider: string
+    ): Promise<UserRecord | null> => {
+      const existing = (await strapi.documents("plugin::users-permissions.user").findFirst({
+        filters: { email },
+        populate: { role: true, player: true } as any,
+        sort: { createdAt: "asc" },
+      })) as (UserRecord & { confirmed?: boolean }) | null
+      if (!existing) return null
+      if (!existing.confirmed) {
+        strapi.log.warn(
+          `[OAuth] User ${email} via ${provider} matches an unconfirmed account (id=${existing.id}); refusing silent merge to prevent account-takeover-by-OAuth`
+        )
+        return null
+      }
+      strapi.log.info(
+        `[OAuth] User ${email} logged in via ${provider}, reusing existing account (original provider: ${existing.provider})`
+      )
+      return existing
     }
 
     // Wrap the connect method
@@ -262,8 +289,10 @@ export default (plugin: StrapiPlugin) => {
       provider: string,
       query: Record<string, unknown>
     ): Promise<UserRecord> => {
-      // Try the proactive path first so we never create a duplicate row.
-      let user: UserRecord | null = await lookupExistingByEmail(provider, query)
+      const profileEmail = await resolveProfileEmail(provider, query)
+      let user: UserRecord | null = profileEmail
+        ? await lookupExistingByEmail(profileEmail, provider)
+        : null
 
       if (!user) {
         try {
@@ -271,36 +300,13 @@ export default (plugin: StrapiPlugin) => {
         } catch (error: unknown) {
           const err = error as { message?: string }
           // Reactive safety net for the narrow race window where a duplicate
-          // gets created between the lookup and originalConnect.
-          if (err.message?.includes("Email is already taken")) {
-            const providersRegistry = strapi
-              .plugin("users-permissions")
-              .service("providers-registry")
-
-            const profile = await providersRegistry.run({
-              provider,
-              accessToken: query.access_token,
-              query,
-              providers: providersRegistry.getAll(),
-            })
-
-            if (profile?.email) {
-              const email = profile.email.toLowerCase()
-              const existingUser = (await strapi
-                .documents("plugin::users-permissions.user")
-                .findFirst({
-                  filters: { email },
-                  populate: { role: true },
-                })) as UserRecord | null
-
-              if (existingUser) {
-                strapi.log.info(
-                  `[OAuth] User ${email} logged in via ${provider}, using existing account (original provider: ${existingUser.provider})`
-                )
-                user = existingUser
-              } else {
-                throw error
-              }
+          // gets created between our lookup and `originalConnect`. We reuse
+          // `profileEmail` rather than re-running the OAuth profile fetch
+          // because many providers won't honour the same access_token twice.
+          if (err.message?.includes("Email is already taken") && profileEmail) {
+            const existing = await lookupExistingByEmail(profileEmail, provider)
+            if (existing) {
+              user = existing
             } else {
               throw error
             }

--- a/packages/api/src/services/import-audience-attendees.ts
+++ b/packages/api/src/services/import-audience-attendees.ts
@@ -948,6 +948,21 @@ export async function runAudienceAttendeeImport(
       } | null
 
       if (existing) {
+        // Refuse to silently rebind the user to a different player than they
+        // already own — surface the conflict so the operator can fix it in
+        // the spreadsheet or the admin UI. Mirrors the policy in
+        // custom-player.ts:1421-1423.
+        if (user.player?.id && existing.player?.id && existing.player.id !== user.player.id) {
+          const message = `Email already linked to a different player (existing player id=${existing.player.id}, import row player id=${user.player.id})`
+          strapi.log.warn(`[Import] ${user.email}: ${message}`)
+          errors.push({
+            email: user.email,
+            name: action.playerName,
+            operation: "createUser",
+            message,
+          })
+          continue
+        }
         strapi.log.info(
           `[Import] Reusing existing user ${existing.documentId} for ${user.email} (was about to create a duplicate)`
         )

--- a/packages/api/src/services/import-audience-attendees.ts
+++ b/packages/api/src/services/import-audience-attendees.ts
@@ -5,6 +5,7 @@ import type { Core } from "@strapi/strapi"
 import slugify from "slugify"
 import { nameToUsername } from "../libs/strings"
 import { sendUserInvitationAndUpdateStatus } from "./user-invitations"
+import { findUserByEmail } from "./users-permissions/find-user-by-email"
 
 type ContactSource = "attendee" | "mailchimp"
 
@@ -936,6 +937,32 @@ export async function runAudienceAttendeeImport(
     if (!user?.planned) continue
 
     try {
+      // Reuse any existing user with this email (case-insensitive) instead of
+      // minting a duplicate. Direct `documents().create()` bypasses the
+      // users-permissions `unique_email` setting, and the LOWER(email) UNIQUE
+      // INDEX would otherwise throw on insert.
+      const existing = (await findUserByEmail(strapi, user.email, { player: true })) as {
+        id: number
+        documentId: string
+        player?: { id?: number } | null
+      } | null
+
+      if (existing) {
+        strapi.log.info(
+          `[Import] Reusing existing user ${existing.documentId} for ${user.email} (was about to create a duplicate)`
+        )
+        if (user.player?.id && !existing.player?.id) {
+          await strapi.documents("plugin::users-permissions.user").update({
+            documentId: existing.documentId,
+            data: { player: user.player.id } as any,
+          })
+        }
+        user.id = existing.id
+        user.documentId = existing.documentId
+        user.planned = false
+        continue
+      }
+
       const password = `${crypto.randomBytes(16).toString("hex")}!`
 
       // Determine role based on player's position

--- a/packages/api/src/services/import-audience-attendees.ts
+++ b/packages/api/src/services/import-audience-attendees.ts
@@ -41,6 +41,10 @@ interface UserRecord {
   username?: string
   player?: PlayerRecord | null
   planned?: boolean
+  // Set to true when we reuse an existing user whose invitation has already
+  // been accepted, so the invitation loop below skips them instead of
+  // re-sending a "set your password" email to a confirmed account.
+  skipInvitation?: boolean
 }
 
 export interface ImportReportRow {
@@ -944,6 +948,7 @@ export async function runAudienceAttendeeImport(
       const existing = (await findUserByEmail(strapi, user.email, { player: true })) as {
         id: number
         documentId: string
+        invitationStatus?: string
         player?: { id?: number } | null
       } | null
 
@@ -963,8 +968,17 @@ export async function runAudienceAttendeeImport(
           })
           continue
         }
+        // Don't re-send an invitation to a user who has already accepted —
+        // that would email them a fresh password-reset link unprompted. They
+        // can still log in normally; the import goal (have a user linked to
+        // this player) is already met.
+        if (existing.invitationStatus === "accepted") {
+          user.skipInvitation = true
+        }
         strapi.log.info(
-          `[Import] Reusing existing user ${existing.documentId} for ${user.email} (was about to create a duplicate)`
+          `[Import] Reusing existing user ${existing.documentId} for ${user.email} ` +
+            `(was about to create a duplicate; invitationStatus=${existing.invitationStatus ?? "unset"}` +
+            `${user.skipInvitation ? "; skipping invitation email" : ""})`
         )
         if (user.player?.id && !existing.player?.id) {
           await strapi.documents("plugin::users-permissions.user").update({
@@ -1067,6 +1081,9 @@ export async function runAudienceAttendeeImport(
   for (const action of actions.createUsers) {
     const user = usersByEmail.get(action.email)
     if (!user?.documentId) continue
+    // Skip invitation for reused users whose invitation has already been
+    // accepted (see `skipInvitation` set in the createUsers loop above).
+    if (user.skipInvitation) continue
 
     const success = await sendUserInvitationAndUpdateStatus(strapi, {
       documentId: user.documentId,

--- a/packages/api/src/services/sender-broadcast.test.ts
+++ b/packages/api/src/services/sender-broadcast.test.ts
@@ -268,7 +268,11 @@ describe("sendTestEmail", () => {
     expect(result).toEqual({ success: true })
     const body = JSON.parse(fetchMock.mock.calls[0][1].body)
     expect(body.from).toEqual({ email: "noreply@play14.org", name: "#play14 community" })
-    expect(body.to).toEqual({ email: "user@example.com" })
+    // Sender.net rejects `{email}` alone — recipients must be plain strings
+    // (or `{email, name}` with both keys). Keep this assertion strict so we
+    // don't regress to the old broken shape that broke multi-admin sends.
+    expect(body.to).toBe("user@example.com")
+    expect(body.reply_to).toBe("community@play14.org")
     expect(body.subject).toBe("[TEST] Hi")
   })
 

--- a/packages/api/src/services/sender-broadcast.ts
+++ b/packages/api/src/services/sender-broadcast.ts
@@ -239,10 +239,15 @@ export async function sendTestEmail(
         "Content-Type": "application/json",
         Accept: "application/json",
       },
+      // Sender.net validates `to` / `reply_to` as either a plain email
+      // string or a `{email, name}` object — `{email}` alone is rejected
+      // with HTTP 422. `from` still requires `{email, name}` (both keys),
+      // hence the asymmetric shape below. See the matching coercion in
+      // packages/api/providers/strapi-provider-email-sender/src/index.js.
       body: JSON.stringify({
         from: fromObj,
-        to: { email },
-        reply_to: { email: replyTo },
+        to: email,
+        reply_to: replyTo,
         subject: `[TEST] ${subject}`,
         html: htmlContent,
       }),

--- a/packages/api/src/services/strapi-provider-email-sender.test.ts
+++ b/packages/api/src/services/strapi-provider-email-sender.test.ts
@@ -59,7 +59,12 @@ describe("strapi-provider-email-sender", () => {
   })
 
   describe("recipients", () => {
-    it("maps a string `to` into a single `{ email }` object", async () => {
+    // Sender.net's `/v2/message/send` validates each recipient as either a
+    // plain email string or a `{ email, name }` object — `{ email }` alone is
+    // rejected with HTTP 422 (`type: "validation"`) as soon as `to` is an
+    // array. We coerce every recipient to a plain string for both `to` and
+    // `reply_to`; the brand name still travels via the `from` field.
+    it("maps a string `to` into a plain email string", async () => {
       const fetchFn = mockOkFetch()
       const sender = createSender()
 
@@ -71,10 +76,10 @@ describe("strapi-provider-email-sender", () => {
       })
 
       const body = lastRequestBody(fetchFn)
-      expect(body.to).toEqual({ email: "player@example.com" })
+      expect(body.to).toBe("player@example.com")
     })
 
-    it("maps an array `to` into an array of `{ email }` objects", async () => {
+    it("maps an array `to` into an array of plain email strings", async () => {
       const fetchFn = mockOkFetch()
       const sender = createSender()
 
@@ -85,10 +90,10 @@ describe("strapi-provider-email-sender", () => {
       })
 
       const body = lastRequestBody(fetchFn)
-      expect(body.to).toEqual([{ email: "a@example.com" }, { email: "b@example.com" }])
+      expect(body.to).toEqual(["a@example.com", "b@example.com"])
     })
 
-    it("maps an array `replyTo` into an array of `{ email }` objects", async () => {
+    it("maps an array `replyTo` into an array of plain email strings", async () => {
       const fetchFn = mockOkFetch()
       const sender = createSender()
 
@@ -100,7 +105,7 @@ describe("strapi-provider-email-sender", () => {
       })
 
       const body = lastRequestBody(fetchFn)
-      expect(body.reply_to).toEqual([{ email: "ops@play14.org" }, { email: "help@play14.org" }])
+      expect(body.reply_to).toEqual(["ops@play14.org", "help@play14.org"])
     })
 
     it("falls back to defaultReplyTo from settings when replyTo is not provided", async () => {
@@ -114,7 +119,21 @@ describe("strapi-provider-email-sender", () => {
       })
 
       const body = lastRequestBody(fetchFn)
-      expect(body.reply_to).toEqual({ email: "default-reply@play14.org" })
+      expect(body.reply_to).toBe("default-reply@play14.org")
+    })
+
+    it("coerces a legacy `{email, name}` object recipient to a plain string", async () => {
+      const fetchFn = mockOkFetch()
+      const sender = createSender()
+
+      await sender.send({
+        from: "sender@play14.org",
+        to: [{ email: "c@example.com", name: "C" }],
+        subject: "Hi",
+      })
+
+      const body = lastRequestBody(fetchFn)
+      expect(body.to).toEqual(["c@example.com"])
     })
   })
 

--- a/packages/api/src/services/strapi-provider-email-sender.test.ts
+++ b/packages/api/src/services/strapi-provider-email-sender.test.ts
@@ -135,6 +135,28 @@ describe("strapi-provider-email-sender", () => {
       const body = lastRequestBody(fetchFn)
       expect(body.to).toEqual(["c@example.com"])
     })
+
+    it("throws synchronously on unrecognised recipient input instead of letting Sender.net 422", async () => {
+      const sender = createSender()
+
+      await expect(
+        sender.send({
+          from: "sender@play14.org",
+          // @ts-expect-error — deliberately wrong shape
+          to: null,
+          subject: "Hi",
+        })
+      ).rejects.toThrow(/Invalid Sender.net recipient/)
+
+      await expect(
+        sender.send({
+          from: "sender@play14.org",
+          // @ts-expect-error — deliberately wrong shape (no .email)
+          to: [{ name: "missing email key" }],
+          subject: "Hi",
+        })
+      ).rejects.toThrow(/Invalid Sender.net recipient/)
+    })
   })
 
   describe("from parsing", () => {

--- a/packages/api/src/services/users-permissions/find-user-by-email.test.ts
+++ b/packages/api/src/services/users-permissions/find-user-by-email.test.ts
@@ -17,6 +17,7 @@ describe("findUserByEmail", () => {
     expect(strapi.documents).toHaveBeenCalledWith("plugin::users-permissions.user")
     expect(findFirst).toHaveBeenCalledWith({
       filters: { email: { $eqi: "GRANT.bosnick@gmail.com" } },
+      sort: { createdAt: "asc" },
     })
   })
 
@@ -28,6 +29,7 @@ describe("findUserByEmail", () => {
 
     expect(findFirst).toHaveBeenCalledWith({
       filters: { email: { $eqi: "user@example.com" } },
+      sort: { createdAt: "asc" },
     })
   })
 
@@ -48,8 +50,21 @@ describe("findUserByEmail", () => {
 
     expect(findFirst).toHaveBeenCalledWith({
       filters: { email: { $eqi: "user@example.com" } },
+      sort: { createdAt: "asc" },
       populate: { player: true },
     })
+  })
+
+  it("sorts by createdAt asc so callers always pick the canonical (oldest) row when duplicates exist", async () => {
+    // Pin the sort. Without it, `findFirst` could return a newer duplicate
+    // during the pre-cleanup window — see comment in find-user-by-email.ts.
+    const findFirst = vi.fn().mockResolvedValue({ id: 1, documentId: "abc" })
+    const strapi = makeStrapi(findFirst)
+
+    await findUserByEmail(strapi, "user@example.com")
+
+    const args = findFirst.mock.calls[0][0]
+    expect(args.sort).toEqual({ createdAt: "asc" })
   })
 
   it("returns the matched user when one exists", async () => {

--- a/packages/api/src/services/users-permissions/find-user-by-email.test.ts
+++ b/packages/api/src/services/users-permissions/find-user-by-email.test.ts
@@ -60,4 +60,14 @@ describe("findUserByEmail", () => {
 
     expect(result).toEqual({ id: 42, documentId: "abc" })
   })
+
+  it("re-throws transient DB errors instead of swallowing them", async () => {
+    // The helper deliberately does NOT swallow rejections — callers need to
+    // distinguish "no row" (null) from "lookup failed" (throw). Future
+    // contributors must NOT add a try/catch here without a load-bearing reason.
+    const findFirst = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"))
+    const strapi = makeStrapi(findFirst)
+
+    await expect(findUserByEmail(strapi, "user@example.com")).rejects.toThrow("ECONNREFUSED")
+  })
 })

--- a/packages/api/src/services/users-permissions/find-user-by-email.test.ts
+++ b/packages/api/src/services/users-permissions/find-user-by-email.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest"
+import { findUserByEmail } from "./find-user-by-email"
+
+function makeStrapi(findFirst: ReturnType<typeof vi.fn>) {
+  return {
+    documents: vi.fn(() => ({ findFirst })),
+  } as any
+}
+
+describe("findUserByEmail", () => {
+  it("queries with a case-insensitive `$eqi` filter on email", async () => {
+    const findFirst = vi.fn().mockResolvedValue(null)
+    const strapi = makeStrapi(findFirst)
+
+    await findUserByEmail(strapi, "GRANT.bosnick@gmail.com")
+
+    expect(strapi.documents).toHaveBeenCalledWith("plugin::users-permissions.user")
+    expect(findFirst).toHaveBeenCalledWith({
+      filters: { email: { $eqi: "GRANT.bosnick@gmail.com" } },
+    })
+  })
+
+  it("trims surrounding whitespace before querying", async () => {
+    const findFirst = vi.fn().mockResolvedValue(null)
+    const strapi = makeStrapi(findFirst)
+
+    await findUserByEmail(strapi, "  user@example.com  ")
+
+    expect(findFirst).toHaveBeenCalledWith({
+      filters: { email: { $eqi: "user@example.com" } },
+    })
+  })
+
+  it("returns null for empty / whitespace-only emails without querying", async () => {
+    const findFirst = vi.fn()
+    const strapi = makeStrapi(findFirst)
+
+    await expect(findUserByEmail(strapi, "")).resolves.toBeNull()
+    await expect(findUserByEmail(strapi, "   ")).resolves.toBeNull()
+    expect(findFirst).not.toHaveBeenCalled()
+  })
+
+  it("passes through populate when provided", async () => {
+    const findFirst = vi.fn().mockResolvedValue({ id: 1, documentId: "abc" })
+    const strapi = makeStrapi(findFirst)
+
+    await findUserByEmail(strapi, "user@example.com", { player: true })
+
+    expect(findFirst).toHaveBeenCalledWith({
+      filters: { email: { $eqi: "user@example.com" } },
+      populate: { player: true },
+    })
+  })
+
+  it("returns the matched user when one exists", async () => {
+    const findFirst = vi.fn().mockResolvedValue({ id: 42, documentId: "abc" })
+    const strapi = makeStrapi(findFirst)
+
+    const result = await findUserByEmail(strapi, "user@example.com")
+
+    expect(result).toEqual({ id: 42, documentId: "abc" })
+  })
+})

--- a/packages/api/src/services/users-permissions/find-user-by-email.ts
+++ b/packages/api/src/services/users-permissions/find-user-by-email.ts
@@ -1,0 +1,31 @@
+import type { Core } from "@strapi/strapi"
+
+/**
+ * Case-insensitive lookup of a `plugin::users-permissions.user` row by email.
+ *
+ * Always call this BEFORE `strapi.documents("plugin::users-permissions.user").create({...})`.
+ * The Document Service `.create()` bypasses the users-permissions `unique_email`
+ * advanced setting (that flag only fires inside `providers.connect` for OAuth
+ * and `auth.register` for local password registration), so without an explicit
+ * lookup the codebase can mint a second user row whose email differs from an
+ * existing one only in case. A functional UNIQUE INDEX on `LOWER(email)` in
+ * the migration `2026.05.22T14.00.00.add-up-users-email-lower-unique.js`
+ * backs this up at the database level; this helper exists so callers can take
+ * the "reuse existing user" branch with a friendly log line instead of
+ * letting the constraint throw at insert time.
+ */
+export async function findUserByEmail<TUser = Record<string, unknown>>(
+  strapi: Core.Strapi,
+  email: string,
+  populate?: Record<string, unknown>
+): Promise<TUser | null> {
+  const trimmed = email?.trim()
+  if (!trimmed) return null
+  const result = await strapi.documents("plugin::users-permissions.user").findFirst({
+    // $eqi is case-insensitive equality. Bypasses the local Strapi types
+    // because the users-permissions content-type doesn't declare it on email.
+    filters: { email: { $eqi: trimmed } } as any,
+    ...(populate ? { populate } : {}),
+  })
+  return (result as TUser | null) ?? null
+}

--- a/packages/api/src/services/users-permissions/find-user-by-email.ts
+++ b/packages/api/src/services/users-permissions/find-user-by-email.ts
@@ -25,6 +25,12 @@ export async function findUserByEmail<TUser = Record<string, unknown>>(
     // $eqi is case-insensitive equality. Bypasses the local Strapi types
     // because the users-permissions content-type doesn't declare it on email.
     filters: { email: { $eqi: trimmed } } as any,
+    // Match the OAuth wrapper's `lookupExistingByEmail` ordering so that
+    // during the pre-cleanup window (when duplicates may still exist), every
+    // caller agrees on which row is canonical: the oldest. Without this sort,
+    // `findFirst` could return a newer player-less row and bind subsequent
+    // player links to the wrong user.
+    sort: { createdAt: "asc" },
     ...(populate ? { populate } : {}),
   })
   return (result as TUser | null) ?? null

--- a/packages/web/src/libs/strapi-client.test.ts
+++ b/packages/web/src/libs/strapi-client.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { buildApiUrl, validatePathSegment, validatePathSegments } from "./strapi-client"
+import {
+  buildApiUrl,
+  extractApiError,
+  validatePathSegment,
+  validatePathSegments,
+} from "./strapi-client"
 
 // Mock process.env for buildApiUrl tests
 const originalEnv = process.env
@@ -230,5 +235,83 @@ describe("buildApiUrl", () => {
     expect(() => buildApiUrl("/events/:slug/edit", { slug: "..%2F..%2Fetc%2Fpasswd" })).toThrow(
       "Invalid slug: contains invalid characters"
     )
+  })
+})
+
+describe("extractApiError", () => {
+  // @strapi/client's HTTPError carries the raw Response on `.response`. The
+  // helper has to clone + parse the body to surface the actual Strapi
+  // `error.message` instead of the generic "Request failed with status code N"
+  // string. These tests pin that contract.
+  function makeHttpError(status: number, body: unknown) {
+    const response = new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    })
+    const error = new Error(
+      `Request failed with status code ${status} Bad Request: PUT /x`
+    ) as Error & {
+      response: Response
+    }
+    error.response = response
+    return error
+  }
+
+  it("surfaces the Strapi error.message from the response body", async () => {
+    const error = makeHttpError(400, {
+      data: null,
+      error: {
+        status: 400,
+        name: "BadRequestError",
+        message: "This player is already linked to another user",
+      },
+    })
+
+    const result = await extractApiError(error)
+
+    expect(result).toEqual({
+      message: "This player is already linked to another user",
+      status: 400,
+    })
+  })
+
+  it("falls back to the raw Error.message when the body has no .error.message", async () => {
+    const error = makeHttpError(500, { unexpected: "shape" })
+
+    const result = await extractApiError(error)
+
+    expect(result.status).toBe(500)
+    expect(result.message).toMatch(/Request failed with status code 500/)
+  })
+
+  it("returns status 0 and the raw message when the error has no .response", async () => {
+    const error = new Error("ECONNREFUSED")
+
+    const result = await extractApiError(error)
+
+    expect(result).toEqual({ message: "ECONNREFUSED", status: 0 })
+  })
+
+  it("returns status 0 and a default message for non-Error throwables", async () => {
+    const result = await extractApiError("oops")
+
+    expect(result).toEqual({ message: "Unknown error occurred", status: 0 })
+  })
+
+  it("never throws when the response body is not valid JSON", async () => {
+    const response = new Response("<html>500</html>", {
+      status: 500,
+      headers: { "Content-Type": "text/html" },
+    })
+    const error = new Error("Request failed with status code 500: GET /x") as Error & {
+      response: Response
+    }
+    error.response = response
+
+    const result = await extractApiError(error)
+
+    expect(result.status).toBe(500)
+    // Falls back to the HTTPError.message — the body is HTML, not JSON
+    expect(result.message).toMatch(/Request failed with status code 500/)
   })
 })

--- a/packages/web/src/libs/strapi-client.ts
+++ b/packages/web/src/libs/strapi-client.ts
@@ -92,6 +92,31 @@ export function buildApiUrl(pathTemplate: string, params: Record<string, string>
 const STRAPI_REST_ENDPOINT = `${(process.env.STRAPI_API_URL || "http://localhost:1337").replace(/\/$/, "")}/api`
 
 /**
+ * Extract the Strapi error message from a thrown error.
+ *
+ * `@strapi/client` throws an `HTTPError` on non-2xx responses whose `.message`
+ * is the generic `"Request failed with status code N <Statustext>: METHOD <url>"`
+ * format — it does NOT include the body. The underlying Response is attached
+ * as `.response`, so we read the JSON body and surface
+ * `errorData.error.message` instead.
+ */
+async function extractApiError(error: unknown): Promise<{ message: string; status: number }> {
+  const fallbackMessage = error instanceof Error ? error.message : "Unknown error occurred"
+  const response = (error as { response?: Response } | null)?.response
+  if (!(response instanceof Response)) {
+    return { message: fallbackMessage, status: 0 }
+  }
+  const errorData = (await response
+    .clone()
+    .json()
+    .catch(() => ({}))) as { error?: { message?: string } }
+  return {
+    message: errorData?.error?.message || fallbackMessage,
+    status: response.status,
+  }
+}
+
+/**
  * Fetch with timeout to prevent hanging connections
  */
 async function fetchWithTimeout(
@@ -551,20 +576,11 @@ export async function strapiFetch<T>(
       data,
     }
   } catch (error) {
-    // Handle "Not authenticated" error for non-auth endpoints gracefully
-    if (noAuth || optionalAuth) {
-      // If auth fails and it's optional, return error result
-      const errorMsg = error instanceof Error ? error.message : "Unknown error occurred"
-      return {
-        ok: false,
-        status: 0,
-        error: errorMsg,
-      }
-    }
+    const { message, status } = await extractApiError(error)
     return {
       ok: false,
-      status: 0,
-      error: error instanceof Error ? error.message : "Unknown error occurred",
+      status,
+      error: message,
     }
   }
 }
@@ -687,18 +703,11 @@ export async function strapiFetchWithQuery<T>(
       data,
     }
   } catch (error) {
-    if (noAuth || optionalAuth) {
-      const errorMsg = error instanceof Error ? error.message : "Unknown error occurred"
-      return {
-        ok: false,
-        status: 0,
-        error: errorMsg,
-      }
-    }
+    const { message, status } = await extractApiError(error)
     return {
       ok: false,
-      status: 0,
-      error: error instanceof Error ? error.message : "Unknown error occurred",
+      status,
+      error: message,
     }
   }
 }

--- a/packages/web/src/libs/strapi-client.ts
+++ b/packages/web/src/libs/strapi-client.ts
@@ -100,7 +100,9 @@ const STRAPI_REST_ENDPOINT = `${(process.env.STRAPI_API_URL || "http://localhost
  * as `.response`, so we read the JSON body and surface
  * `errorData.error.message` instead.
  */
-async function extractApiError(error: unknown): Promise<{ message: string; status: number }> {
+export async function extractApiError(
+  error: unknown
+): Promise<{ message: string; status: number }> {
   const fallbackMessage = error instanceof Error ? error.message : "Unknown error occurred"
   const response = (error as { response?: Response } | null)?.response
   if (!(response instanceof Response)) {


### PR DESCRIPTION
@strapi/client throws an HTTPError on non-2xx responses whose .message is
the generic "Request failed with status code N <Statustext>: METHOD <url>"
format, masking the actual API error (e.g. "This player is already linked
to another user"). Add an extractApiError helper that reads error.response
and pulls errorData.error.message off the body, then wire it into the
catch blocks of strapiFetch and strapiFetchWithQuery.