### PR TITLE
feat: create players from the admin list + fix participant add (slug, public-page refresh)

### DIFF
--- a/packages/api/src/api/event/controllers/custom-event.test.ts
+++ b/packages/api/src/api/event/controllers/custom-event.test.ts
@@ -1,6 +1,7 @@
 import type { Core } from "@strapi/strapi"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { acquireLock } from "../../../services/cron/distributed-lock"
+import { triggerContentRevalidation } from "../../../services/frontend-revalidation"
 import {
   addPlayerToEventAttendees,
   removePlayerFromEventAttendees,
@@ -10,6 +11,9 @@ import customEventFactory from "./custom-event"
 vi.mock("../../../libs/tickets", () => ({
   generateTicketCode: vi.fn(() => "TKT-TEST-1234"),
   generateOrderNumber: vi.fn(() => "P14-TEST-0001"),
+}))
+vi.mock("../../../services/frontend-revalidation", () => ({
+  triggerContentRevalidation: vi.fn(),
 }))
 vi.mock("../../../services/ticketing/player-service", () => ({
   addPlayerToEventAttendees: vi.fn(),
@@ -65,7 +69,14 @@ const PLAYER_UID = "api::player.player"
 const TICKET_UID = "api::ticket.ticket"
 const TICKET_TYPE_UID = "api::ticket-type.ticket-type"
 
-const EVENT = { id: 10, documentId: "evt-1", name: "Test Event", hosts: [], mentors: [] }
+const EVENT = {
+  id: 10,
+  documentId: "evt-1",
+  name: "Test Event",
+  slug: "test-event",
+  hosts: [],
+  mentors: [],
+}
 
 describe("custom-event.addParticipant", () => {
   beforeEach(() => {
@@ -254,8 +265,10 @@ describe("custom-event.addParticipant", () => {
 
     await customEventFactory({ strapi }).addParticipant(ctx)
 
+    // slug MUST be set on create: Strapi 5 validates the required slug field before the
+    // beforeCreate lifecycle runs, so a create without it fails with "slug must be defined".
     expect(model(PLAYER_UID).create).toHaveBeenCalledWith({
-      data: expect.objectContaining({ name: "New Person", position: "Player" }),
+      data: expect.objectContaining({ name: "New Person", slug: "new-person", position: "Player" }),
     })
     // Reused the existing external type — did not create a second one
     expect(model(TICKET_TYPE_UID).create).not.toHaveBeenCalled()
@@ -271,6 +284,13 @@ describe("custom-event.addParticipant", () => {
       "ply-7",
       { documentId: "evt-1", id: 10 },
       "[Event]"
+    )
+    // Public event page is revalidated so the new attendee shows up
+    expect(triggerContentRevalidation).toHaveBeenCalledWith(
+      strapi,
+      "api::event.event",
+      { slug: "test-event" },
+      "update"
     )
   })
 
@@ -588,6 +608,13 @@ describe("custom-event.removeParticipant", () => {
       "[Event]"
     )
     expect(ctx.send).toHaveBeenCalledWith({ data: { documentId: "tk-1", removed: true } })
+    // Public event page is revalidated so the removed attendee disappears
+    expect(triggerContentRevalidation).toHaveBeenCalledWith(
+      strapi,
+      "api::event.event",
+      { slug: "test-event" },
+      "update"
+    )
   })
 
   it("keeps the player on the attendee list when another valid ticket remains", async () => {

--- a/packages/api/src/api/event/controllers/custom-event.ts
+++ b/packages/api/src/api/event/controllers/custom-event.ts
@@ -7,11 +7,15 @@
 import * as fs from "node:fs"
 import type { Core } from "@strapi/strapi"
 import { imageSize } from "image-size"
-import { toSlug } from "../../../libs/strings"
 import { generateTicketCode } from "../../../libs/tickets"
 import { validateEmail } from "../../../libs/validation"
 import { acquireLock, releaseLock } from "../../../services/cron/distributed-lock"
 import { triggerContentRevalidation } from "../../../services/frontend-revalidation"
+import {
+  createUnlinkedPlayer,
+  PLAYER_NAME_SIMILAR_MESSAGE,
+  PLAYER_NAME_TAKEN_MESSAGE,
+} from "../../../services/player/create-player"
 import {
   addPlayerToEventAttendees,
   removePlayerFromEventAttendees,
@@ -2311,8 +2315,11 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
     // NOTE: like the sibling participant endpoints (getParticipants), this operates on
     // the organizer's event whether draft or published — addPlayerToEventAttendees below
     // syncs the attendee into BOTH versions, and tickets are linked by event regardless.
+    // `slug` is selected explicitly because the success path revalidates the public event
+    // page by slug; keep it here so the dependency is visible and can't be dropped silently.
     const event = await strapi.documents("api::event.event").findOne({
       documentId: eventId,
+      fields: ["name", "slug"],
       populate: {
         hosts: { fields: ["documentId"] },
         mentors: { fields: ["documentId"] },
@@ -2385,42 +2392,21 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
           return ctx.notFound("Player not found")
         }
       } else {
-        // player.name is unique — reject exact matches so the organizer picks the existing one.
-        const existing = await strapi.documents("api::player.player").findMany({
-          filters: { name: { $eqi: newPlayerName } },
-          fields: ["documentId"],
+        // Create a standalone player. createUnlinkedPlayer owns the shared rules (reject an
+        // exact name match, set the required slug since Strapi validates it before the
+        // beforeCreate lifecycle, map a slug-collision to a 400). Genuine errors throw and are
+        // caught by the outer try/catch below (which rolls back and rethrows as a 500).
+        const created = await createUnlinkedPlayer(strapi, {
+          name: newPlayerName,
+          company: newPlayer?.company,
         })
-        if (existing.length > 0) {
-          return ctx.badRequest(
-            "A player with this name already exists. Select the existing player instead."
-          )
+        if (created.status === "name-exists") {
+          return ctx.badRequest(PLAYER_NAME_TAKEN_MESSAGE)
         }
-        // The player schema marks `slug` required, and Strapi 5's Document Service validates
-        // required fields BEFORE the `beforeCreate` lifecycle runs — so the lifecycle's slug
-        // derivation can't satisfy validation and we MUST set the slug on create (every other
-        // player-create path does too). We use the same toSlug(name) the lifecycle would, so the
-        // two agree. Two names that slugify identically ("Rémi" vs "Remi") still collide on the
-        // slug unique constraint; surface that as a clear 400 instead of a 500. Retrying is
-        // pointless — the slug would be regenerated the same.
-        try {
-          participantPlayer = await strapi.documents("api::player.player").create({
-            data: {
-              name: newPlayerName,
-              slug: toSlug(newPlayerName),
-              position: "Player",
-              company: newPlayer?.company?.trim() || null,
-            } as any,
-          })
-        } catch (err) {
-          if (/unique|duplicate|already exists/i.test(String(err))) {
-            strapi.log.warn(`[Event] Name/slug conflict creating player "${newPlayerName}": ${err}`)
-            return ctx.badRequest(
-              "A player with this name (or a very similar one) already exists. Select the existing player instead."
-            )
-          }
-          strapi.log.error(`[Event] Failed to create player "${newPlayerName}": ${err}`)
-          throw err
+        if (created.status === "slug-conflict") {
+          return ctx.badRequest(PLAYER_NAME_SIMILAR_MESSAGE)
         }
+        participantPlayer = created.player
         createdPlayerDocId = participantPlayer.documentId
         strapi.log.info(
           `[Event] Created player ${participantPlayer.documentId} ("${newPlayerName}") while adding participant to "${event.name}" by ${player.name}`
@@ -2504,12 +2490,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
       // Refresh the public event page: adding the attendee only updates the player record
       // (which revalidates the player page via its lifecycle), so the event's attendee list
       // would otherwise stay stale until the next event edit. Revalidate the event explicitly.
-      triggerContentRevalidation(
-        strapi,
-        "api::event.event",
-        { slug: (event as any).slug },
-        "update"
-      )
+      triggerContentRevalidation(strapi, "api::event.event", { slug: event.slug }, "update")
 
       return ctx.send({
         data: {
@@ -2576,8 +2557,11 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
       return ctx.forbidden("You must have a linked player profile")
     }
 
+    // `slug` is selected explicitly because the success path revalidates the public event
+    // page by slug; keep it here so the dependency is visible and can't be dropped silently.
     const event = await strapi.documents("api::event.event").findOne({
       documentId: eventId,
+      fields: ["name", "slug"],
       populate: {
         hosts: { fields: ["documentId"] },
         mentors: { fields: ["documentId"] },
@@ -2671,12 +2655,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
 
       // Refresh the public event page so the removed attendee disappears from its list
       // (see addParticipant — the attendee change lives on the player record, not the event).
-      triggerContentRevalidation(
-        strapi,
-        "api::event.event",
-        { slug: (event as any).slug },
-        "update"
-      )
+      triggerContentRevalidation(strapi, "api::event.event", { slug: event.slug }, "update")
 
       return ctx.send({ data: { documentId: ticketId, removed: true } })
     } finally {

--- a/packages/api/src/api/event/controllers/custom-event.ts
+++ b/packages/api/src/api/event/controllers/custom-event.ts
@@ -7,9 +7,11 @@
 import * as fs from "node:fs"
 import type { Core } from "@strapi/strapi"
 import { imageSize } from "image-size"
+import { toSlug } from "../../../libs/strings"
 import { generateTicketCode } from "../../../libs/tickets"
 import { validateEmail } from "../../../libs/validation"
 import { acquireLock, releaseLock } from "../../../services/cron/distributed-lock"
+import { triggerContentRevalidation } from "../../../services/frontend-revalidation"
 import {
   addPlayerToEventAttendees,
   removePlayerFromEventAttendees,
@@ -2393,15 +2395,18 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
             "A player with this name already exists. Select the existing player instead."
           )
         }
-        // NOTE: the player `beforeCreate` lifecycle derives the slug from the name
-        // (slug = toSlug(name)) and overwrites anything we set, so we don't compute a slug
-        // here. Two names that slugify identically ("Rémi" vs "Remi") therefore collide on
-        // the slug unique constraint; surface that as a clear 400 instead of a 500. Retrying
-        // is pointless — the lifecycle would regenerate the same slug.
+        // The player schema marks `slug` required, and Strapi 5's Document Service validates
+        // required fields BEFORE the `beforeCreate` lifecycle runs — so the lifecycle's slug
+        // derivation can't satisfy validation and we MUST set the slug on create (every other
+        // player-create path does too). We use the same toSlug(name) the lifecycle would, so the
+        // two agree. Two names that slugify identically ("Rémi" vs "Remi") still collide on the
+        // slug unique constraint; surface that as a clear 400 instead of a 500. Retrying is
+        // pointless — the slug would be regenerated the same.
         try {
           participantPlayer = await strapi.documents("api::player.player").create({
             data: {
               name: newPlayerName,
+              slug: toSlug(newPlayerName),
               position: "Player",
               company: newPlayer?.company?.trim() || null,
             } as any,
@@ -2494,6 +2499,16 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
 
       strapi.log.info(
         `[Event] Participant added to "${event.name}" by ${player.name}: ${attendeeName} (${ticket.ticketCode})`
+      )
+
+      // Refresh the public event page: adding the attendee only updates the player record
+      // (which revalidates the player page via its lifecycle), so the event's attendee list
+      // would otherwise stay stale until the next event edit. Revalidate the event explicitly.
+      triggerContentRevalidation(
+        strapi,
+        "api::event.event",
+        { slug: (event as any).slug },
+        "update"
       )
 
       return ctx.send({
@@ -2652,6 +2667,15 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
 
       strapi.log.info(
         `[Event] Participant removed from "${event.name}" by ${player.name}: ${ticket.ticketCode}`
+      )
+
+      // Refresh the public event page so the removed attendee disappears from its list
+      // (see addParticipant — the attendee change lives on the player record, not the event).
+      triggerContentRevalidation(
+        strapi,
+        "api::event.event",
+        { slug: (event as any).slug },
+        "update"
       )
 
       return ctx.send({ data: { documentId: ticketId, removed: true } })

--- a/packages/api/src/api/player/controllers/custom-player.test.ts
+++ b/packages/api/src/api/player/controllers/custom-player.test.ts
@@ -1,0 +1,170 @@
+import type { Core } from "@strapi/strapi"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import customPlayerFactory from "./custom-player"
+
+// The controller module pulls in email rendering + side services at import time; stub the
+// heavy ones so this unit test stays focused on createPlayer's own logic.
+vi.mock("@react-email/render", () => ({ render: vi.fn(async () => "<html></html>") }))
+vi.mock("../../../emails/user-invitation", () => ({ default: () => null }))
+vi.mock("../../../services/email-send", () => ({ sendEmail: vi.fn() }))
+vi.mock("../../../services/sender-subscribers", () => ({ addSubscriberToGroup: vi.fn() }))
+vi.mock("../../../services/user-role-sync", () => ({ syncUserRoleFromPlayer: vi.fn() }))
+vi.mock("../../../services/users-permissions/find-user-by-email", () => ({
+  findUserByEmail: vi.fn(),
+}))
+
+const createMockStrapi = () => {
+  const models: Record<string, ReturnType<typeof makeModel>> = {}
+  const makeModel = () => ({
+    findOne: vi.fn(),
+    findFirst: vi.fn(),
+    findMany: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  })
+  const model = (uid: string) => {
+    if (!models[uid]) models[uid] = makeModel()
+    return models[uid]
+  }
+  const strapi = {
+    documents: vi.fn((uid: string) => model(uid)),
+    log: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  } as unknown as Core.Strapi
+  return { strapi, model }
+}
+
+const createMockContext = (overrides: Partial<any> = {}) => ({
+  state: { user: null },
+  params: {},
+  query: {},
+  request: { body: {} },
+  send: vi.fn(),
+  unauthorized: vi.fn(),
+  forbidden: vi.fn(),
+  badRequest: vi.fn(),
+  notFound: vi.fn(),
+  internalServerError: vi.fn(),
+  ...overrides,
+})
+
+const USER_UID = "plugin::users-permissions.user"
+const PLAYER_UID = "api::player.player"
+
+describe("custom-player.createPlayer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  /** Wire an organizer (Founder) user by default. */
+  const setupOrganizer = () => {
+    const mocks = createMockStrapi()
+    mocks.model(USER_UID).findFirst.mockResolvedValue({
+      id: 1,
+      player: { documentId: "host-1", name: "Host One", position: "Founder" },
+    })
+    return mocks
+  }
+
+  it("returns unauthorized when not logged in", async () => {
+    const { strapi } = createMockStrapi()
+    const ctx = createMockContext()
+    await customPlayerFactory({ strapi }).createPlayer(ctx)
+    expect(ctx.unauthorized).toHaveBeenCalled()
+  })
+
+  it("returns forbidden when the caller is only a Player (not an organizer)", async () => {
+    const { strapi, model } = createMockStrapi()
+    model(USER_UID).findFirst.mockResolvedValue({
+      id: 2,
+      player: { documentId: "player-x", name: "Reg", position: "Player" },
+    })
+    const ctx = createMockContext({
+      state: { user: { id: 2 } },
+      request: { body: { data: { name: "New Person" } } },
+    })
+    await customPlayerFactory({ strapi }).createPlayer(ctx)
+    expect(ctx.forbidden).toHaveBeenCalled()
+    expect(model(PLAYER_UID).create).not.toHaveBeenCalled()
+  })
+
+  it("rejects a name shorter than 2 characters", async () => {
+    const { strapi, model } = setupOrganizer()
+    const ctx = createMockContext({
+      state: { user: { id: 1 } },
+      request: { body: { data: { name: "A" } } },
+    })
+    await customPlayerFactory({ strapi }).createPlayer(ctx)
+    expect(ctx.badRequest).toHaveBeenCalledWith(
+      "Name is required and must be at least 2 characters"
+    )
+    expect(model(PLAYER_UID).create).not.toHaveBeenCalled()
+  })
+
+  it("rejects a name that already exists", async () => {
+    const { strapi, model } = setupOrganizer()
+    model(PLAYER_UID).findMany.mockResolvedValue([{ documentId: "ply-existing" }])
+    const ctx = createMockContext({
+      state: { user: { id: 1 } },
+      request: { body: { data: { name: "Existing Name" } } },
+    })
+    await customPlayerFactory({ strapi }).createPlayer(ctx)
+    expect(ctx.badRequest).toHaveBeenCalledWith(
+      "A player with this name already exists. Select the existing player instead."
+    )
+    expect(model(PLAYER_UID).create).not.toHaveBeenCalled()
+  })
+
+  it("creates an unlinked player with a slug set (slug is required before the lifecycle runs)", async () => {
+    const { strapi, model } = setupOrganizer()
+    model(PLAYER_UID).findMany.mockResolvedValue([]) // no name clash
+    model(PLAYER_UID).create.mockResolvedValue({
+      documentId: "ply-new",
+      slug: "new-person",
+      name: "New Person",
+      position: "Player",
+      company: "ACME",
+    })
+    const ctx = createMockContext({
+      state: { user: { id: 1 } },
+      request: { body: { data: { name: "  New Person  ", company: " ACME " } } },
+    })
+
+    await customPlayerFactory({ strapi }).createPlayer(ctx)
+
+    expect(model(PLAYER_UID).create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        name: "New Person",
+        slug: "new-person",
+        company: "ACME",
+        position: "Player",
+      }),
+    })
+    expect(ctx.send).toHaveBeenCalledWith({
+      data: {
+        documentId: "ply-new",
+        slug: "new-person",
+        name: "New Person",
+        position: "Player",
+        company: "ACME",
+      },
+    })
+  })
+
+  it("returns a clear clash message (not a 500) when create hits the unique constraint", async () => {
+    const { strapi, model } = setupOrganizer()
+    model(PLAYER_UID).findMany.mockResolvedValue([])
+    model(PLAYER_UID).create.mockRejectedValue(new Error("duplicate key value violates unique"))
+    const ctx = createMockContext({
+      state: { user: { id: 1 } },
+      request: { body: { data: { name: "Rémi" } } },
+    })
+
+    await customPlayerFactory({ strapi }).createPlayer(ctx)
+
+    expect(ctx.badRequest).toHaveBeenCalledWith(
+      "A player with this name (or a very similar one) already exists. Select the existing player instead."
+    )
+    expect(ctx.internalServerError).not.toHaveBeenCalled()
+  })
+})

--- a/packages/api/src/api/player/controllers/custom-player.ts
+++ b/packages/api/src/api/player/controllers/custom-player.ts
@@ -9,9 +9,15 @@ import type { Core } from "@strapi/strapi"
 import slugify from "slugify"
 import UserInvitationEmail from "../../../emails/user-invitation"
 import { sanitizeHtml, sanitizePlainText } from "../../../libs/sanitize"
-import { nameToUsername, toSlug } from "../../../libs/strings"
+import { nameToUsername } from "../../../libs/strings"
 import { isValidEmail, isValidUrl } from "../../../libs/validation"
 import { sendEmail } from "../../../services/email-send"
+import {
+  type CreateUnlinkedPlayerResult,
+  createUnlinkedPlayer,
+  PLAYER_NAME_SIMILAR_MESSAGE,
+  PLAYER_NAME_TAKEN_MESSAGE,
+} from "../../../services/player/create-player"
 import { addSubscriberToGroup } from "../../../services/sender-subscribers"
 import { syncUserRoleFromPlayer } from "../../../services/user-role-sync"
 import { findUserByEmail } from "../../../services/users-permissions/find-user-by-email"
@@ -461,55 +467,35 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
     }
     const trimmedName = name.trim()
 
-    // player.name is unique — reject exact (case-insensitive) matches so the organizer
-    // picks the existing one instead of creating a duplicate.
-    const existing = await strapi.documents("api::player.player").findMany({
-      filters: { name: { $eqi: trimmedName } },
-      fields: ["documentId"],
-    })
-    if (existing.length > 0) {
-      return ctx.badRequest(
-        "A player with this name already exists. Select the existing player instead."
-      )
-    }
-
+    let result: CreateUnlinkedPlayerResult
     try {
-      // slug is `required` and Strapi 5 validates it BEFORE the beforeCreate lifecycle runs, so
-      // we MUST set it here. We use the same toSlug(name) the lifecycle derives, so the two agree.
-      const newPlayer = await strapi.documents("api::player.player").create({
-        data: {
-          name: trimmedName,
-          slug: toSlug(trimmedName),
-          company: typeof company === "string" && company.trim() ? company.trim() : null,
-          position: "Player",
-        } as any,
-      })
-
-      strapi.log.info(
-        `[Player] Organizer ${userWithPlayer.player.name} created player ${newPlayer.documentId} ("${trimmedName}")`
-      )
-
-      return ctx.send({
-        data: {
-          documentId: newPlayer.documentId,
-          slug: newPlayer.slug,
-          name: newPlayer.name,
-          position: newPlayer.position,
-          company: (newPlayer as any).company ?? null,
-        },
-      })
+      result = await createUnlinkedPlayer(strapi, { name: trimmedName, company })
     } catch (err) {
-      // Diacritic-equivalent names ("Rémi" vs "Remi") collide on the slug unique constraint —
-      // surface that as a clear 400 rather than a 500. Retrying is pointless (same slug).
-      if (/unique|duplicate|already exists/i.test(String(err))) {
-        strapi.log.warn(`[Player] Name/slug conflict creating player "${trimmedName}": ${err}`)
-        return ctx.badRequest(
-          "A player with this name (or a very similar one) already exists. Select the existing player instead."
-        )
-      }
       strapi.log.error(`[Player] Failed to create player "${trimmedName}": ${err}`)
       return ctx.internalServerError("Failed to create player profile")
     }
+
+    if (result.status === "name-exists") {
+      return ctx.badRequest(PLAYER_NAME_TAKEN_MESSAGE)
+    }
+    if (result.status === "slug-conflict") {
+      return ctx.badRequest(PLAYER_NAME_SIMILAR_MESSAGE)
+    }
+
+    const newPlayer = result.player
+    strapi.log.info(
+      `[Player] Organizer ${userWithPlayer.player.name} created player ${newPlayer.documentId} ("${trimmedName}")`
+    )
+
+    return ctx.send({
+      data: {
+        documentId: newPlayer.documentId,
+        slug: newPlayer.slug,
+        name: newPlayer.name,
+        position: newPlayer.position,
+        company: newPlayer.company ?? null,
+      },
+    })
   },
 
   /**

--- a/packages/api/src/api/player/controllers/custom-player.ts
+++ b/packages/api/src/api/player/controllers/custom-player.ts
@@ -9,7 +9,7 @@ import type { Core } from "@strapi/strapi"
 import slugify from "slugify"
 import UserInvitationEmail from "../../../emails/user-invitation"
 import { sanitizeHtml, sanitizePlainText } from "../../../libs/sanitize"
-import { nameToUsername } from "../../../libs/strings"
+import { nameToUsername, toSlug } from "../../../libs/strings"
 import { isValidEmail, isValidUrl } from "../../../libs/validation"
 import { sendEmail } from "../../../services/email-send"
 import { addSubscriberToGroup } from "../../../services/sender-subscribers"
@@ -422,6 +422,92 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
       })
     } catch (error) {
       strapi.log.error(`[Player] Failed to create player: ${error}`)
+      return ctx.internalServerError("Failed to create player profile")
+    }
+  },
+
+  /**
+   * Create a standalone player profile (organizer only).
+   *
+   * Unlike createForUser (which links the new player to the CURRENT user), this
+   * creates an UNLINKED player — used by organizers to register people who aren't
+   * yet in the directory (e.g. before adding them to an event). No user account,
+   * no invite, no email is created.
+   */
+  async createPlayer(ctx) {
+    const user = ctx.state.user
+
+    if (!user) {
+      return ctx.unauthorized("You must be logged in")
+    }
+
+    // Only organizers (Host and above) can create players directly.
+    const userWithPlayer = await strapi.documents("plugin::users-permissions.user").findFirst({
+      filters: { id: user.id },
+      populate: { player: true },
+    })
+
+    if (!userWithPlayer?.player) {
+      return ctx.forbidden("You must have a linked player profile")
+    }
+    if (userWithPlayer.player.position === "Player") {
+      return ctx.forbidden("Only organizers can create players")
+    }
+
+    const { name, company } = ctx.request.body?.data || {}
+
+    if (!name || typeof name !== "string" || name.trim().length < 2) {
+      return ctx.badRequest("Name is required and must be at least 2 characters")
+    }
+    const trimmedName = name.trim()
+
+    // player.name is unique — reject exact (case-insensitive) matches so the organizer
+    // picks the existing one instead of creating a duplicate.
+    const existing = await strapi.documents("api::player.player").findMany({
+      filters: { name: { $eqi: trimmedName } },
+      fields: ["documentId"],
+    })
+    if (existing.length > 0) {
+      return ctx.badRequest(
+        "A player with this name already exists. Select the existing player instead."
+      )
+    }
+
+    try {
+      // slug is `required` and Strapi 5 validates it BEFORE the beforeCreate lifecycle runs, so
+      // we MUST set it here. We use the same toSlug(name) the lifecycle derives, so the two agree.
+      const newPlayer = await strapi.documents("api::player.player").create({
+        data: {
+          name: trimmedName,
+          slug: toSlug(trimmedName),
+          company: typeof company === "string" && company.trim() ? company.trim() : null,
+          position: "Player",
+        } as any,
+      })
+
+      strapi.log.info(
+        `[Player] Organizer ${userWithPlayer.player.name} created player ${newPlayer.documentId} ("${trimmedName}")`
+      )
+
+      return ctx.send({
+        data: {
+          documentId: newPlayer.documentId,
+          slug: newPlayer.slug,
+          name: newPlayer.name,
+          position: newPlayer.position,
+          company: (newPlayer as any).company ?? null,
+        },
+      })
+    } catch (err) {
+      // Diacritic-equivalent names ("Rémi" vs "Remi") collide on the slug unique constraint —
+      // surface that as a clear 400 rather than a 500. Retrying is pointless (same slug).
+      if (/unique|duplicate|already exists/i.test(String(err))) {
+        strapi.log.warn(`[Player] Name/slug conflict creating player "${trimmedName}": ${err}`)
+        return ctx.badRequest(
+          "A player with this name (or a very similar one) already exists. Select the existing player instead."
+        )
+      }
+      strapi.log.error(`[Player] Failed to create player "${trimmedName}": ${err}`)
       return ctx.internalServerError("Failed to create player profile")
     }
   },

--- a/packages/api/src/api/player/routes/custom-player.ts
+++ b/packages/api/src/api/player/routes/custom-player.ts
@@ -62,6 +62,17 @@ export default {
     },
     {
       method: "POST",
+      path: "/admin/players",
+      handler: "custom-player.createPlayer",
+      info: { apiName: "player", type: "content-api" },
+      config: {
+        policies: [],
+        middlewares: [],
+        description: "Create a standalone (unlinked) player profile (organizer only)",
+      },
+    },
+    {
+      method: "POST",
       path: "/players/auto-link",
       handler: "custom-player.autoLink",
       info: { apiName: "player", type: "content-api" },

--- a/packages/api/src/bootstrap/permissions/actions.ts
+++ b/packages/api/src/bootstrap/permissions/actions.ts
@@ -92,6 +92,7 @@ export const PLAYER_ACTIONS = {
   FIND_ME: "api::player.custom-player.findMe",
   UPDATE_ME: "api::player.custom-player.updateMe",
   CREATE_FOR_USER: "api::player.custom-player.createForUser",
+  CREATE_PLAYER: "api::player.custom-player.createPlayer",
   AUTO_LINK: "api::player.custom-player.autoLink",
   UPLOAD_PICTURE: "api::player.custom-player.uploadPicture",
   DELETE_PICTURE: "api::player.custom-player.deletePicture",

--- a/packages/api/src/bootstrap/permissions/definitions.ts
+++ b/packages/api/src/bootstrap/permissions/definitions.ts
@@ -165,6 +165,7 @@ export const PERMISSION_DEFINITIONS: PermissionDefinition[] = [
 
   // Player management (for event organizers)
   { action: PLAYER_ACTIONS.LIST_PLAYERS, minimumRole: ROLE_TYPES.HOST },
+  { action: PLAYER_ACTIONS.CREATE_PLAYER, minimumRole: ROLE_TYPES.HOST },
   { action: PLAYER_ACTIONS.GET_PLAYER_FOR_EDIT, minimumRole: ROLE_TYPES.HOST },
   { action: PLAYER_ACTIONS.UPDATE_PLAYER, minimumRole: ROLE_TYPES.HOST },
   { action: PLAYER_ACTIONS.UPDATE_PLAYER_POSITION, minimumRole: ROLE_TYPES.HOST },

--- a/packages/api/src/services/player/create-player.test.ts
+++ b/packages/api/src/services/player/create-player.test.ts
@@ -1,0 +1,76 @@
+import type { Core } from "@strapi/strapi"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { createUnlinkedPlayer } from "./create-player"
+
+const createMockStrapi = () => {
+  const model = {
+    findMany: vi.fn(),
+    create: vi.fn(),
+  }
+  const strapi = {
+    documents: vi.fn(() => model),
+    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  } as unknown as Core.Strapi
+  return { strapi, model }
+}
+
+describe("createUnlinkedPlayer", () => {
+  let strapi: Core.Strapi
+  let model: { findMany: ReturnType<typeof vi.fn>; create: ReturnType<typeof vi.fn> }
+
+  beforeEach(() => {
+    const m = createMockStrapi()
+    strapi = m.strapi
+    model = m.model
+    model.findMany.mockResolvedValue([]) // no name clash by default
+  })
+
+  it("returns name-exists and never creates when an exact name already exists", async () => {
+    model.findMany.mockResolvedValue([{ documentId: "ply-existing" }])
+
+    const result = await createUnlinkedPlayer(strapi, { name: "Jane Doe" })
+
+    expect(result).toEqual({ status: "name-exists" })
+    expect(model.create).not.toHaveBeenCalled()
+  })
+
+  it("creates with slug=toSlug(name), trimmed company, and position Player", async () => {
+    model.create.mockResolvedValue({ documentId: "ply-1", name: "Jane Doe", slug: "jane-doe" })
+
+    const result = await createUnlinkedPlayer(strapi, { name: "Jane Doe", company: "  ACME  " })
+
+    expect(model.create).toHaveBeenCalledWith({
+      data: { name: "Jane Doe", slug: "jane-doe", company: "ACME", position: "Player" },
+    })
+    expect(result).toEqual({
+      status: "created",
+      player: { documentId: "ply-1", name: "Jane Doe", slug: "jane-doe" },
+    })
+  })
+
+  it("coerces blank/non-string company to null", async () => {
+    model.create.mockResolvedValue({ documentId: "ply-2" })
+
+    await createUnlinkedPlayer(strapi, { name: "No Co", company: "   " })
+    await createUnlinkedPlayer(strapi, { name: "No Co 2", company: 42 })
+
+    expect(model.create.mock.calls[0][0].data.company).toBeNull()
+    expect(model.create.mock.calls[1][0].data.company).toBeNull()
+  })
+
+  it("maps a unique-constraint violation to slug-conflict (not a throw)", async () => {
+    model.create.mockRejectedValue(new Error("duplicate key value violates unique constraint"))
+
+    const result = await createUnlinkedPlayer(strapi, { name: "Rémi" })
+
+    expect(result).toEqual({ status: "slug-conflict" })
+  })
+
+  it("rethrows a non-uniqueness error for the caller to handle", async () => {
+    model.create.mockRejectedValue(new Error("connection refused"))
+
+    await expect(createUnlinkedPlayer(strapi, { name: "Boom" })).rejects.toThrow(
+      "connection refused"
+    )
+  })
+})

--- a/packages/api/src/services/player/create-player.ts
+++ b/packages/api/src/services/player/create-player.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared player-creation helper for organizer-driven flows.
+ *
+ * Several endpoints need to create a standalone (unlinked) player from a name:
+ * the admin "create player" action and the event "add participant" new-player
+ * path. This centralises the rules they share so they can't drift.
+ */
+
+import type { Core } from "@strapi/strapi"
+import { toSlug } from "../../libs/strings"
+
+/** Shown when an exact (case-insensitive) name already exists. */
+export const PLAYER_NAME_TAKEN_MESSAGE =
+  "A player with this name already exists. Select the existing player instead."
+
+/** Shown when a different name collides on the derived slug (e.g. "Rémi" vs "Remi"). */
+export const PLAYER_NAME_SIMILAR_MESSAGE =
+  "A player with this name (or a very similar one) already exists. Select the existing player instead."
+
+export type CreateUnlinkedPlayerResult =
+  | { status: "created"; player: any }
+  | { status: "name-exists" }
+  | { status: "slug-conflict" }
+
+/**
+ * Create a standalone (unlinked) player profile from a name (+ optional company).
+ *
+ * Encapsulates the rules every organizer-driven create shares:
+ * - rejects an exact (case-insensitive) name match → `{ status: "name-exists" }`
+ * - sets `slug = toSlug(name)` because Strapi 5 validates the required `slug`
+ *   field BEFORE the `beforeCreate` lifecycle runs, so the lifecycle can't
+ *   satisfy validation — the create must carry a slug (the value matches what
+ *   the lifecycle would derive, so they agree)
+ * - maps a unique-constraint violation (e.g. diacritic-equivalent names that
+ *   slugify identically) to `{ status: "slug-conflict" }` instead of a 500
+ *
+ * Genuine (non-uniqueness) errors are rethrown for the caller to handle. Does
+ * NOT link a user, send an invite, or email — callers own enrollment.
+ *
+ * @param name - already-trimmed player name (callers validate length up front)
+ */
+export async function createUnlinkedPlayer(
+  strapi: Core.Strapi,
+  { name, company }: { name: string; company?: unknown }
+): Promise<CreateUnlinkedPlayerResult> {
+  // player.name is unique — reject exact matches so the organizer picks the existing one.
+  const existing = await strapi.documents("api::player.player").findMany({
+    filters: { name: { $eqi: name } },
+    fields: ["documentId"],
+  })
+  if (existing.length > 0) return { status: "name-exists" }
+
+  const companyValue = typeof company === "string" && company.trim() ? company.trim() : null
+
+  try {
+    const player = await strapi.documents("api::player.player").create({
+      data: {
+        name,
+        slug: toSlug(name),
+        company: companyValue,
+        position: "Player",
+      } as any,
+    })
+    return { status: "created", player }
+  } catch (err) {
+    if (/unique|duplicate|already exists/i.test(String(err))) {
+      strapi.log.warn(`[Player] Name/slug conflict creating player "${name}": ${err}`)
+      return { status: "slug-conflict" }
+    }
+    throw err
+  }
+}

--- a/packages/web/messages/de.json
+++ b/packages/web/messages/de.json
@@ -2034,7 +2034,19 @@
         "viewPlayer": "Spieler ansehen",
         "previous": "Zurück",
         "next": "Weiter",
-        "pageOf": "Seite {page} von {pageCount}"
+        "pageOf": "Seite {page} von {pageCount}",
+        "createPlayer": "Spieler anlegen",
+        "createPlayerTitle": "Neuen Spieler anlegen",
+        "createPlayerHint": "Erstellt ein Profil, das nicht mit einem Benutzerkonto verknüpft ist. Du kannst diesen Spieler anschließend zu einem Event hinzufügen.",
+        "createNameLabel": "Name",
+        "createNamePlaceholder": "Vollständiger Name",
+        "createCompanyLabel": "Unternehmen (optional)",
+        "createCompanyPlaceholder": "Unternehmen oder Organisation",
+        "createCancel": "Abbrechen",
+        "createSubmit": "Spieler anlegen",
+        "creating": "Wird angelegt…",
+        "createNameTooShort": "Der Name muss mindestens 2 Zeichen lang sein",
+        "createFailed": "Spieler konnte nicht angelegt werden"
       },
       "invite": {
         "title": "Einladung senden",

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -1224,7 +1224,19 @@
         "viewPlayer": "View player",
         "previous": "Previous",
         "next": "Next",
-        "pageOf": "Page {page} of {pageCount}"
+        "pageOf": "Page {page} of {pageCount}",
+        "createPlayer": "Create player",
+        "createPlayerTitle": "Create a new player",
+        "createPlayerHint": "Creates a profile that isn't linked to a user account. You can then add this player to an event.",
+        "createNameLabel": "Name",
+        "createNamePlaceholder": "Full name",
+        "createCompanyLabel": "Company (optional)",
+        "createCompanyPlaceholder": "Company or organisation",
+        "createCancel": "Cancel",
+        "createSubmit": "Create player",
+        "creating": "Creating…",
+        "createNameTooShort": "Name must be at least 2 characters",
+        "createFailed": "Failed to create player"
       },
       "invite": {
         "title": "Send invite",

--- a/packages/web/messages/es.json
+++ b/packages/web/messages/es.json
@@ -1316,7 +1316,19 @@
         "viewPlayer": "Ver jugador",
         "previous": "Anterior",
         "next": "Siguiente",
-        "pageOf": "Página {page} de {pageCount}"
+        "pageOf": "Página {page} de {pageCount}",
+        "createPlayer": "Crear jugador",
+        "createPlayerTitle": "Crear un nuevo jugador",
+        "createPlayerHint": "Crea un perfil no vinculado a una cuenta de usuario. Luego podrás añadir este jugador a un evento.",
+        "createNameLabel": "Nombre",
+        "createNamePlaceholder": "Nombre completo",
+        "createCompanyLabel": "Empresa (opcional)",
+        "createCompanyPlaceholder": "Empresa u organización",
+        "createCancel": "Cancelar",
+        "createSubmit": "Crear jugador",
+        "creating": "Creando…",
+        "createNameTooShort": "El nombre debe tener al menos 2 caracteres",
+        "createFailed": "No se pudo crear el jugador"
       },
       "invite": {
         "title": "Enviar invitación",

--- a/packages/web/messages/fr.json
+++ b/packages/web/messages/fr.json
@@ -1316,7 +1316,19 @@
         "viewPlayer": "Voir le joueur",
         "previous": "Précédent",
         "next": "Suivant",
-        "pageOf": "Page {page} sur {pageCount}"
+        "pageOf": "Page {page} sur {pageCount}",
+        "createPlayer": "Créer un joueur",
+        "createPlayerTitle": "Créer un nouveau joueur",
+        "createPlayerHint": "Crée un profil non lié à un compte utilisateur. Vous pourrez ensuite ajouter ce joueur à un événement.",
+        "createNameLabel": "Nom",
+        "createNamePlaceholder": "Nom complet",
+        "createCompanyLabel": "Entreprise (facultatif)",
+        "createCompanyPlaceholder": "Entreprise ou organisation",
+        "createCancel": "Annuler",
+        "createSubmit": "Créer le joueur",
+        "creating": "Création…",
+        "createNameTooShort": "Le nom doit comporter au moins 2 caractères",
+        "createFailed": "Échec de la création du joueur"
       },
       "invite": {
         "title": "Envoyer une invitation",

--- a/packages/web/messages/it.json
+++ b/packages/web/messages/it.json
@@ -1224,7 +1224,19 @@
         "viewPlayer": "Vedi giocatore",
         "previous": "Precedente",
         "next": "Successivo",
-        "pageOf": "Pagina {page} di {pageCount}"
+        "pageOf": "Pagina {page} di {pageCount}",
+        "createPlayer": "Crea giocatore",
+        "createPlayerTitle": "Crea un nuovo giocatore",
+        "createPlayerHint": "Crea un profilo non collegato a un account utente. Potrai poi aggiungere questo giocatore a un evento.",
+        "createNameLabel": "Nome",
+        "createNamePlaceholder": "Nome completo",
+        "createCompanyLabel": "Azienda (facoltativo)",
+        "createCompanyPlaceholder": "Azienda o organizzazione",
+        "createCancel": "Annulla",
+        "createSubmit": "Crea giocatore",
+        "creating": "Creazione…",
+        "createNameTooShort": "Il nome deve contenere almeno 2 caratteri",
+        "createFailed": "Creazione del giocatore non riuscita"
       },
       "invite": {
         "title": "Invia invito",

--- a/packages/web/src/app/[locale]/(admin)/admin/players/players-list.tsx
+++ b/packages/web/src/app/[locale]/(admin)/admin/players/players-list.tsx
@@ -4,7 +4,12 @@ import { useTranslations } from "next-intl"
 import { useCallback, useEffect, useRef, useState } from "react"
 import Avatar from "@/components/ui/avatar"
 import { Link } from "@/i18n/navigation"
-import { getPlayers, type PlayerListItem, type PlayersListResponse } from "./players.action"
+import {
+  createPlayer,
+  getPlayers,
+  type PlayerListItem,
+  type PlayersListResponse,
+} from "./players.action"
 
 const ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("")
 const POSITIONS = ["Founder", "Mentor", "Host", "Player"] as const
@@ -39,6 +44,14 @@ export default function PlayersList() {
   const [searchQuery, setSearchQuery] = useState("")
   const [debouncedSearch, setDebouncedSearch] = useState("")
   const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+
+  // Create-player modal state
+  const [showCreateModal, setShowCreateModal] = useState(false)
+  const [createName, setCreateName] = useState("")
+  const [createCompany, setCreateCompany] = useState("")
+  const [createError, setCreateError] = useState<string | null>(null)
+  const [creating, setCreating] = useState(false)
+  const createModalRef = useRef<HTMLDivElement>(null)
 
   const fetchPlayers = useCallback(
     async (letter: string | null, page = 1, search?: string, position?: Position | null) => {
@@ -120,6 +133,55 @@ export default function PlayersList() {
     fetchPlayers(selectedLetter, newPage, debouncedSearch, selectedPosition)
   }
 
+  const closeCreateModal = useCallback(() => {
+    if (creating) return
+    setShowCreateModal(false)
+    setCreateName("")
+    setCreateCompany("")
+    setCreateError(null)
+  }, [creating])
+
+  // Modal a11y: lock body scroll, move focus into the open dialog, and close on Escape.
+  useEffect(() => {
+    if (!showCreateModal) return
+    createModalRef.current?.focus()
+    document.body.style.overflow = "hidden"
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") closeCreateModal()
+    }
+    document.addEventListener("keydown", handleEscape)
+    return () => {
+      document.body.style.overflow = ""
+      document.removeEventListener("keydown", handleEscape)
+    }
+  }, [showCreateModal, closeCreateModal])
+
+  const handleCreatePlayer = async () => {
+    const name = createName.trim()
+    if (name.length < 2) {
+      setCreateError(t("createNameTooShort"))
+      return
+    }
+    setCreating(true)
+    setCreateError(null)
+
+    const result = await createPlayer(name, createCompany.trim() || undefined)
+
+    setCreating(false)
+    if (!result.success) {
+      setCreateError(result.error || t("createFailed"))
+      return
+    }
+
+    // Close the modal and surface the new player by searching for its name.
+    setShowCreateModal(false)
+    setCreateName("")
+    setCreateCompany("")
+    setSelectedLetter(null)
+    setSelectedPosition(null)
+    setSearchQuery(name)
+  }
+
   if (isLoading && players.length === 0) {
     return (
       <div className="claims-loading">
@@ -149,6 +211,16 @@ export default function PlayersList() {
   return (
     <div className="players-list">
       <div className="players-toolbar">
+        <div className="players-actions">
+          <button
+            type="button"
+            className="admin-btn admin-btn-primary"
+            onClick={() => setShowCreateModal(true)}
+          >
+            <i className="bx bx-user-plus" />
+            {t("createPlayer")}
+          </button>
+        </div>
         <div className="players-search">
           <div className="search-input-wrapper">
             <i className="bx bx-search" />
@@ -328,6 +400,99 @@ export default function PlayersList() {
             </div>
           )}
         </>
+      )}
+
+      {showCreateModal && (
+        <div className="admin-modal-overlay" onClick={closeCreateModal}>
+          <div
+            ref={createModalRef}
+            className="admin-modal"
+            onClick={(e) => e.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="create-player-title"
+            tabIndex={-1}
+          >
+            <div className="admin-modal-header">
+              <h3 id="create-player-title">{t("createPlayerTitle")}</h3>
+              <button
+                type="button"
+                className="admin-modal-close"
+                onClick={closeCreateModal}
+                aria-label={t("createCancel")}
+              >
+                <i className="bx bx-x" />
+              </button>
+            </div>
+
+            <div className="admin-modal-body">
+              <p className="admin-form-help">{t("createPlayerHint")}</p>
+
+              {createError && (
+                <div className="admin-alert admin-alert-error admin-alert-sm">
+                  <i className="bx bx-error-circle" />
+                  {createError}
+                </div>
+              )}
+
+              <div className="admin-form-group">
+                <label htmlFor="create-player-name">{t("createNameLabel")}</label>
+                <input
+                  id="create-player-name"
+                  type="text"
+                  className="admin-input"
+                  placeholder={t("createNamePlaceholder")}
+                  value={createName}
+                  onChange={(e) => {
+                    setCreateName(e.target.value)
+                    setCreateError(null)
+                  }}
+                />
+              </div>
+
+              <div className="admin-form-group">
+                <label htmlFor="create-player-company">{t("createCompanyLabel")}</label>
+                <input
+                  id="create-player-company"
+                  type="text"
+                  className="admin-input"
+                  placeholder={t("createCompanyPlaceholder")}
+                  value={createCompany}
+                  onChange={(e) => setCreateCompany(e.target.value)}
+                />
+              </div>
+            </div>
+
+            <div className="admin-modal-footer">
+              <button
+                type="button"
+                className="admin-btn admin-btn-secondary"
+                onClick={closeCreateModal}
+                disabled={creating}
+              >
+                {t("createCancel")}
+              </button>
+              <button
+                type="button"
+                className="admin-btn admin-btn-primary"
+                onClick={handleCreatePlayer}
+                disabled={creating || createName.trim().length < 2}
+              >
+                {creating ? (
+                  <>
+                    <i className="bx bx-loader-alt bx-spin" />
+                    {t("creating")}
+                  </>
+                ) : (
+                  <>
+                    <i className="bx bx-user-plus" />
+                    {t("createSubmit")}
+                  </>
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   )

--- a/packages/web/src/app/[locale]/(admin)/admin/players/players.action.ts
+++ b/packages/web/src/app/[locale]/(admin)/admin/players/players.action.ts
@@ -105,6 +105,46 @@ export async function getPlayers(
   return result.data || emptyResponse
 }
 
+export interface CreatedPlayer {
+  documentId: string
+  slug: string
+  name: string
+  position: string
+  company: string | null
+}
+
+export interface CreatePlayerResult {
+  success: boolean
+  error?: string
+  data?: CreatedPlayer
+}
+
+/**
+ * Create a standalone (unlinked) player profile (organizers only).
+ *
+ * The new player isn't linked to any user account and no invite/email is sent —
+ * it can then be added to an event as a participant via the event's participants tab.
+ */
+export async function createPlayer(name: string, company?: string): Promise<CreatePlayerResult> {
+  const result = await strapiFetch<{ data: CreatedPlayer }>(
+    "/admin/players",
+    {},
+    {
+      method: "POST",
+      body: { data: { name, company: company || undefined } },
+    }
+  )
+
+  if (!result.ok) {
+    return { success: false, error: result.error || "Failed to create player" }
+  }
+
+  // Refresh the public player directory so the new profile shows up
+  revalidatePlayerPages(result.data?.data?.slug)
+
+  return { success: true, data: result.data?.data }
+}
+
 /**
  * Get a player for editing
  */

--- a/packages/web/src/styles/admin/_forms.scss
+++ b/packages/web/src/styles/admin/_forms.scss
@@ -2505,6 +2505,11 @@ label.admin-btn {
   gap: 12px;
 }
 
+.players-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
 .players-search {
   width: 100%;
   max-width: 400px;


### PR DESCRIPTION
## What & why

Three issues reported on the organizer participant flow, plus a "create player" entry point:

1. **Public event page not refreshed after adding a participant.** Adding/removing an attendee only mutates the *player* record, so the player page revalidated but the *event* page kept a stale attendee list. `addParticipant`/`removeParticipant` now explicitly revalidate the event page by slug.

2. **"slug must be defined" when creating a new player.** Strapi 5's Document Service validates the required `slug` field *before* the `beforeCreate` lifecycle runs, so the lifecycle's slug derivation can never satisfy validation — the create must carry a slug. Restored `slug = toSlug(name)` (consistent with every other programmatic player-create path).

3. **No way to create a player from the players list.** Added an organizer-only `POST /admin/players` endpoint (creates an unlinked player — no user/invite/email) and a "Create player" button + modal on the admin players list. The new player can then be added to an event from the participants tab.

## Changes

**API**
- `addParticipant`/`removeParticipant`: set `slug` on new-player create; trigger event-page revalidation after add/remove; select `fields: ["name", "slug"]` so the revalidation slug is an explicit, undroppable dependency.
- New `POST /admin/players` → `custom-player.createPlayer` (HOST+), wired into the permissions bootstrap (`CREATE_PLAYER`).
- Extracted a shared `createUnlinkedPlayer` service so the create + name-conflict + slug-collision→400 logic lives in one place (used by `createPlayer` and `addParticipant`).

**Web**
- "Create player" button + accessible modal on `/admin/players` (focus-on-open, Escape, scroll-lock — matches the existing admin-modal pattern).
- New `createPlayer` server action; copy synced across all 5 locales (en/fr/de/es/it).

## Verification
- API typecheck ✅ · **535 unit tests pass** (incl. new `createPlayer` + `createUnlinkedPlayer` specs) · Biome clean · permissions audit 215/215 · i18n 5 locales in sync.
- Booted the API locally and confirmed it starts and serves (the earlier `EADDRINUSE :9000` was an unrelated stale-process port conflict).

## Notes
- A `/review` pass found no correctness bugs; the actionable cleanups (#2 explicit slug, #3 shared helper) are included. Deferred: extracting a shared `AdminModal` (focus-trap/restore) — a codebase-wide a11y improvement touching several existing modals, out of scope here.