### PR TITLE
fix(web): recover from stale-chunk errors + styled admin error boundary

### DIFF
--- a/packages/web/src/app/[locale]/(admin)/error.tsx
+++ b/packages/web/src/app/[locale]/(admin)/error.tsx
@@ -4,7 +4,11 @@ import { useTranslations } from "next-intl"
 import ErrorMessage from "@/components/layout/error-message"
 import { useChunkErrorRecovery } from "@/hooks/use-chunk-error-recovery"
 
-export default function Error({
+// Admin-section error boundary. Without this, errors under /admin bubble all the
+// way up to global-error.tsx (a bare, unstyled fallback). This keeps them inside
+// the locale layout so they render the styled #play14 error UI — and auto-reloads
+// on a stale-chunk error after a deploy.
+export default function AdminError({
   error,
   reset,
 }: {
@@ -23,7 +27,7 @@ export default function Error({
     )
   }
 
-  // Detect connection errors
+  // Detect connection errors (mirrors the public (main) boundary)
   const isConnectionError =
     error.message.includes("fetch failed") ||
     error.cause?.code === "ECONNRESET" ||

--- a/packages/web/src/app/[locale]/(admin)/error.tsx
+++ b/packages/web/src/app/[locale]/(admin)/error.tsx
@@ -1,50 +1,14 @@
 "use client" // Error components must be Client Components
 
-import { useTranslations } from "next-intl"
-import ErrorMessage from "@/components/layout/error-message"
-import { useChunkErrorRecovery } from "@/hooks/use-chunk-error-recovery"
-import { isConnectionError } from "@/libs/connection-error"
+import LocaleError from "@/components/layout/locale-error"
 
 // Admin-section error boundary. Without this, errors under /admin bubble all the
 // way up to global-error.tsx (a bare, unstyled fallback). This keeps them inside
 // the locale layout so they render the styled #play14 error UI — and auto-reloads
-// on a stale-chunk error after a deploy.
-export default function AdminError({
-  error,
-  reset,
-}: {
+// on a stale-chunk error after a deploy (shared logic in LocaleError).
+export default function AdminError(props: {
   error: Error & { digest?: string; cause?: Error & { code?: string } }
   reset: () => void
 }) {
-  const t = useTranslations("common")
-  const reloading = useChunkErrorRecovery(error)
-
-  if (reloading) {
-    // Stale chunk after a deploy — a full reload is in flight; avoid flashing an error.
-    return (
-      <div className="pt-70" style={{ textAlign: "center", padding: "4rem 1rem" }}>
-        <i className="bx bx-loader-alt bx-spin" style={{ fontSize: "2rem" }} aria-hidden="true" />
-      </div>
-    )
-  }
-
-  const connectionError = isConnectionError(error)
-
-  return (
-    <div className="pt-70">
-      <ErrorMessage
-        title={connectionError ? t("serverUnavailable") : t("error")}
-        message={connectionError ? t("serverUnavailableDescription") : error.message || t("error")}
-        details={
-          process.env.NODE_ENV === "development"
-            ? `${error.message}\n${error.stack || ""}`
-            : undefined
-        }
-        retryLabel={t("tryAgain")}
-        onRetry={reset}
-        // Suppress the report link on connection errors — those aren't bugs to file.
-        error={connectionError ? undefined : error}
-      />
-    </div>
-  )
+  return <LocaleError {...props} />
 }

--- a/packages/web/src/app/[locale]/(admin)/error.tsx
+++ b/packages/web/src/app/[locale]/(admin)/error.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from "next-intl"
 import ErrorMessage from "@/components/layout/error-message"
 import { useChunkErrorRecovery } from "@/hooks/use-chunk-error-recovery"
+import { isConnectionError } from "@/libs/connection-error"
 
 // Admin-section error boundary. Without this, errors under /admin bubble all the
 // way up to global-error.tsx (a bare, unstyled fallback). This keeps them inside
@@ -27,20 +28,13 @@ export default function AdminError({
     )
   }
 
-  // Detect connection errors (mirrors the public (main) boundary)
-  const isConnectionError =
-    error.message.includes("fetch failed") ||
-    error.cause?.code === "ECONNRESET" ||
-    error.message.includes("ECONNREFUSED") ||
-    error.message.includes("ECONNABORTED")
+  const connectionError = isConnectionError(error)
 
   return (
     <div className="pt-70">
       <ErrorMessage
-        title={isConnectionError ? t("serverUnavailable") : t("error")}
-        message={
-          isConnectionError ? t("serverUnavailableDescription") : error.message || t("error")
-        }
+        title={connectionError ? t("serverUnavailable") : t("error")}
+        message={connectionError ? t("serverUnavailableDescription") : error.message || t("error")}
         details={
           process.env.NODE_ENV === "development"
             ? `${error.message}\n${error.stack || ""}`
@@ -49,7 +43,7 @@ export default function AdminError({
         retryLabel={t("tryAgain")}
         onRetry={reset}
         // Suppress the report link on connection errors — those aren't bugs to file.
-        error={isConnectionError ? undefined : error}
+        error={connectionError ? undefined : error}
       />
     </div>
   )

--- a/packages/web/src/app/[locale]/(main)/error.tsx
+++ b/packages/web/src/app/[locale]/(main)/error.tsx
@@ -1,46 +1,10 @@
 "use client" // Error components must be Client Components
 
-import { useTranslations } from "next-intl"
-import ErrorMessage from "@/components/layout/error-message"
-import { useChunkErrorRecovery } from "@/hooks/use-chunk-error-recovery"
-import { isConnectionError } from "@/libs/connection-error"
+import LocaleError from "@/components/layout/locale-error"
 
-export default function Error({
-  error,
-  reset,
-}: {
+export default function Error(props: {
   error: Error & { digest?: string; cause?: Error & { code?: string } }
   reset: () => void
 }) {
-  const t = useTranslations("common")
-  const reloading = useChunkErrorRecovery(error)
-
-  if (reloading) {
-    // Stale chunk after a deploy — a full reload is in flight; avoid flashing an error.
-    return (
-      <div className="pt-70" style={{ textAlign: "center", padding: "4rem 1rem" }}>
-        <i className="bx bx-loader-alt bx-spin" style={{ fontSize: "2rem" }} aria-hidden="true" />
-      </div>
-    )
-  }
-
-  const connectionError = isConnectionError(error)
-
-  return (
-    <div className="pt-70">
-      <ErrorMessage
-        title={connectionError ? t("serverUnavailable") : t("error")}
-        message={connectionError ? t("serverUnavailableDescription") : error.message || t("error")}
-        details={
-          process.env.NODE_ENV === "development"
-            ? `${error.message}\n${error.stack || ""}`
-            : undefined
-        }
-        retryLabel={t("tryAgain")}
-        onRetry={reset}
-        // Suppress the report link on connection errors — those aren't bugs to file.
-        error={connectionError ? undefined : error}
-      />
-    </div>
-  )
+  return <LocaleError {...props} />
 }

--- a/packages/web/src/app/[locale]/(main)/error.tsx
+++ b/packages/web/src/app/[locale]/(main)/error.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from "next-intl"
 import ErrorMessage from "@/components/layout/error-message"
 import { useChunkErrorRecovery } from "@/hooks/use-chunk-error-recovery"
+import { isConnectionError } from "@/libs/connection-error"
 
 export default function Error({
   error,
@@ -23,20 +24,13 @@ export default function Error({
     )
   }
 
-  // Detect connection errors
-  const isConnectionError =
-    error.message.includes("fetch failed") ||
-    error.cause?.code === "ECONNRESET" ||
-    error.message.includes("ECONNREFUSED") ||
-    error.message.includes("ECONNABORTED")
+  const connectionError = isConnectionError(error)
 
   return (
     <div className="pt-70">
       <ErrorMessage
-        title={isConnectionError ? t("serverUnavailable") : t("error")}
-        message={
-          isConnectionError ? t("serverUnavailableDescription") : error.message || t("error")
-        }
+        title={connectionError ? t("serverUnavailable") : t("error")}
+        message={connectionError ? t("serverUnavailableDescription") : error.message || t("error")}
         details={
           process.env.NODE_ENV === "development"
             ? `${error.message}\n${error.stack || ""}`
@@ -45,7 +39,7 @@ export default function Error({
         retryLabel={t("tryAgain")}
         onRetry={reset}
         // Suppress the report link on connection errors — those aren't bugs to file.
-        error={isConnectionError ? undefined : error}
+        error={connectionError ? undefined : error}
       />
     </div>
   )

--- a/packages/web/src/app/[locale]/(main)/events/error.tsx
+++ b/packages/web/src/app/[locale]/(main)/events/error.tsx
@@ -1,9 +1,10 @@
 "use client" // Error components must be Client Components
 
 import { useTranslations } from "next-intl"
-import { useEffect } from "react"
 import ErrorMessage from "@/components/layout/error-message"
 import Page from "@/components/layout/page"
+import { useChunkErrorRecovery } from "@/hooks/use-chunk-error-recovery"
+import { isConnectionError } from "@/libs/connection-error"
 
 export default function EventsError({
   error,
@@ -12,25 +13,27 @@ export default function EventsError({
   error: Error & { digest?: string; cause?: Error & { code?: string } }
   reset: () => void
 }) {
-  useEffect(() => {
-    // Log the error to an error reporting service
-    console.error("Events page error:", error)
-  }, [error])
-
   const t = useTranslations("events")
+  const reloading = useChunkErrorRecovery(error)
 
-  // Detect connection errors
-  const isConnectionError =
-    error.message.includes("fetch failed") ||
-    error.cause?.code === "ECONNRESET" ||
-    error.message.includes("ECONNREFUSED") ||
-    error.message.includes("ECONNABORTED")
+  if (reloading) {
+    // Stale chunk after a deploy — a full reload is in flight; avoid flashing an error.
+    return (
+      <Page name={t("title")}>
+        <div style={{ textAlign: "center", padding: "4rem 1rem" }}>
+          <i className="bx bx-loader-alt bx-spin" style={{ fontSize: "2rem" }} aria-hidden="true" />
+        </div>
+      </Page>
+    )
+  }
+
+  const connectionError = isConnectionError(error)
 
   return (
     <Page name={t("title")}>
       <ErrorMessage
-        title={isConnectionError ? t("errorUnableToLoad") : t("errorLoading")}
-        message={isConnectionError ? t("errorConnection") : error.message || t("errorGeneric")}
+        title={connectionError ? t("errorUnableToLoad") : t("errorLoading")}
+        message={connectionError ? t("errorConnection") : error.message || t("errorGeneric")}
         details={
           process.env.NODE_ENV === "development"
             ? `${error.message}\n${error.stack || ""}`
@@ -38,7 +41,7 @@ export default function EventsError({
         }
         onRetry={reset}
         // Suppress the report link on connection errors — those aren't bugs to file.
-        error={isConnectionError ? undefined : error}
+        error={connectionError ? undefined : error}
       />
     </Page>
   )

--- a/packages/web/src/app/global-error.tsx
+++ b/packages/web/src/app/global-error.tsx
@@ -2,17 +2,20 @@
 
 import { useChunkErrorRecovery } from "@/hooks/use-chunk-error-recovery"
 import { useIssueReportUrl } from "@/hooks/use-issue-report-url"
+import { isConnectionError } from "@/libs/connection-error"
 
 // Renders outside the next-intl provider — strings are intentionally hardcoded in English.
 export default function GlobalError({
   error,
   reset,
 }: {
-  error: Error & { digest?: string }
+  error: Error & { digest?: string; cause?: Error & { code?: string } }
   reset: () => void
 }) {
   const issueUrl = useIssueReportUrl(error)
   const reloading = useChunkErrorRecovery(error)
+  // A dropped connection isn't a bug to file — show a connectivity message and hide the report link.
+  const connectionError = isConnectionError(error)
 
   // Stale chunk after a deploy — a full reload is in flight; show a neutral placeholder.
   // This renders its own document (no app CSS), so styles are inline.
@@ -53,7 +56,9 @@ export default function GlobalError({
             color: "#333",
           }}
         >
-          <h1 style={{ marginBottom: "1rem", fontSize: "2rem" }}>Something went wrong</h1>
+          <h1 style={{ marginBottom: "1rem", fontSize: "2rem" }}>
+            {connectionError ? "Can't reach the server" : "Something went wrong"}
+          </h1>
           <p
             style={{
               marginBottom: "2rem",
@@ -62,7 +67,9 @@ export default function GlobalError({
               maxWidth: "400px",
             }}
           >
-            An unexpected error occurred. Our team has been notified and is working to fix it.
+            {connectionError
+              ? "We couldn't reach the server. Please check your connection and try again."
+              : "An unexpected error occurred. Our team has been notified and is working to fix it."}
           </p>
           <div
             style={{
@@ -91,7 +98,7 @@ export default function GlobalError({
             >
               Try again
             </button>
-            {issueUrl && (
+            {!connectionError && issueUrl && (
               <a
                 href={issueUrl}
                 target="_blank"

--- a/packages/web/src/app/global-error.tsx
+++ b/packages/web/src/app/global-error.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect } from "react"
+import { useChunkErrorRecovery } from "@/hooks/use-chunk-error-recovery"
 import { useIssueReportUrl } from "@/hooks/use-issue-report-url"
 
 // Renders outside the next-intl provider — strings are intentionally hardcoded in English.
@@ -12,10 +12,30 @@ export default function GlobalError({
   reset: () => void
 }) {
   const issueUrl = useIssueReportUrl(error)
+  const reloading = useChunkErrorRecovery(error)
 
-  useEffect(() => {
-    console.error("Global error:", error)
-  }, [error])
+  // Stale chunk after a deploy — a full reload is in flight; show a neutral placeholder.
+  // This renders its own document (no app CSS), so styles are inline.
+  if (reloading) {
+    return (
+      <html lang="en">
+        <body>
+          <div
+            style={{
+              minHeight: "100vh",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontFamily: "system-ui, sans-serif",
+              color: "#666",
+            }}
+          >
+            Reloading…
+          </div>
+        </body>
+      </html>
+    )
+  }
 
   return (
     <html lang="en">

--- a/packages/web/src/components/layout/locale-error.tsx
+++ b/packages/web/src/components/layout/locale-error.tsx
@@ -1,47 +1,52 @@
-"use client" // Error components must be Client Components
+"use client"
 
 import { useTranslations } from "next-intl"
 import ErrorMessage from "@/components/layout/error-message"
 import Loader from "@/components/layout/loader"
-import Page from "@/components/layout/page"
 import { useChunkErrorRecovery } from "@/hooks/use-chunk-error-recovery"
 import { isConnectionError } from "@/libs/connection-error"
 
-export default function EventsError({
-  error,
-  reset,
-}: {
+interface Props {
   error: Error & { digest?: string; cause?: Error & { code?: string } }
   reset: () => void
-}) {
-  const t = useTranslations("events")
+}
+
+/**
+ * Shared body for the locale-level error boundaries — (main) and (admin), which
+ * were otherwise near-identical. Auto-reloads on a stale-chunk error after a
+ * deploy; otherwise shows the styled #play14 error UI, with a connection-error
+ * variant (suppresses the bug-report link for network blips).
+ */
+export default function LocaleError({ error, reset }: Props) {
+  const t = useTranslations("common")
   const reloading = useChunkErrorRecovery(error)
 
   if (reloading) {
     // Stale chunk after a deploy — a full reload is in flight; avoid flashing an error.
     return (
-      <Page name={t("title")}>
+      <div className="pt-70">
         <Loader />
-      </Page>
+      </div>
     )
   }
 
   const connectionError = isConnectionError(error)
 
   return (
-    <Page name={t("title")}>
+    <div className="pt-70">
       <ErrorMessage
-        title={connectionError ? t("errorUnableToLoad") : t("errorLoading")}
-        message={connectionError ? t("errorConnection") : error.message || t("errorGeneric")}
+        title={connectionError ? t("serverUnavailable") : t("error")}
+        message={connectionError ? t("serverUnavailableDescription") : error.message || t("error")}
         details={
           process.env.NODE_ENV === "development"
             ? `${error.message}\n${error.stack || ""}`
             : undefined
         }
+        retryLabel={t("tryAgain")}
         onRetry={reset}
         // Suppress the report link on connection errors — those aren't bugs to file.
         error={connectionError ? undefined : error}
       />
-    </Page>
+    </div>
   )
 }

--- a/packages/web/src/hooks/use-chunk-error-recovery.ts
+++ b/packages/web/src/hooks/use-chunk-error-recovery.ts
@@ -1,7 +1,11 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import { recoverFromChunkError, willRecoverFromChunkError } from "@/libs/chunk-error"
+import {
+  isChunkLoadError,
+  recoverFromChunkError,
+  willRecoverFromChunkError,
+} from "@/libs/chunk-error"
 
 /**
  * For use inside an error boundary (`error.tsx` / `global-error.tsx`).
@@ -21,8 +25,11 @@ export function useChunkErrorRecovery(error: unknown): boolean {
       setReloading(true)
       return
     }
+    // A chunk error that didn't trigger a reload means recovery already fired (the
+    // guard is active — e.g. React StrictMode re-running this effect, or a prior
+    // reload). Don't log it or flash the error UI; the reload is in flight.
+    if (isChunkLoadError(error)) return
     setReloading(false)
-    // Log only errors we're actually surfacing (a reloaded chunk error is expected).
     console.error(error)
   }, [error])
 

--- a/packages/web/src/hooks/use-chunk-error-recovery.ts
+++ b/packages/web/src/hooks/use-chunk-error-recovery.ts
@@ -1,7 +1,7 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import { isChunkLoadError, recoverFromChunkError } from "@/libs/chunk-error"
+import { recoverFromChunkError, willRecoverFromChunkError } from "@/libs/chunk-error"
 
 /**
  * For use inside an error boundary (`error.tsx` / `global-error.tsx`).
@@ -12,8 +12,9 @@ import { isChunkLoadError, recoverFromChunkError } from "@/libs/chunk-error"
  * an error UI. Genuine (non-chunk) errors are logged and surfaced as normal.
  */
 export function useChunkErrorRecovery(error: unknown): boolean {
-  // Start in the reloading state for a chunk error so we never flash the error UI.
-  const [reloading, setReloading] = useState(() => isChunkLoadError(error))
+  // Initialise to whether a reload will actually fire, so we never flash the error UI
+  // before reloading — nor flash the spinner when the reload is guard-suppressed.
+  const [reloading, setReloading] = useState(() => willRecoverFromChunkError(error))
 
   useEffect(() => {
     if (recoverFromChunkError(error)) {

--- a/packages/web/src/hooks/use-chunk-error-recovery.ts
+++ b/packages/web/src/hooks/use-chunk-error-recovery.ts
@@ -1,0 +1,29 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { isChunkLoadError, recoverFromChunkError } from "@/libs/chunk-error"
+
+/**
+ * For use inside an error boundary (`error.tsx` / `global-error.tsx`).
+ *
+ * Auto-reloads once when the boundary catches a stale-chunk error after a
+ * deployment (see `@/libs/chunk-error`). Returns `true` while a reload is
+ * pending so the boundary can render a neutral placeholder instead of flashing
+ * an error UI. Genuine (non-chunk) errors are logged and surfaced as normal.
+ */
+export function useChunkErrorRecovery(error: unknown): boolean {
+  // Start in the reloading state for a chunk error so we never flash the error UI.
+  const [reloading, setReloading] = useState(() => isChunkLoadError(error))
+
+  useEffect(() => {
+    if (recoverFromChunkError(error)) {
+      setReloading(true)
+      return
+    }
+    setReloading(false)
+    // Log only errors we're actually surfacing (a reloaded chunk error is expected).
+    console.error(error)
+  }, [error])
+
+  return reloading
+}

--- a/packages/web/src/libs/chunk-error.test.ts
+++ b/packages/web/src/libs/chunk-error.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { isChunkLoadError, recoverFromChunkError } from "./chunk-error"
+import { isChunkLoadError, recoverFromChunkError, willRecoverFromChunkError } from "./chunk-error"
 
 describe("isChunkLoadError", () => {
   it("matches by error name", () => {
@@ -23,7 +23,82 @@ describe("isChunkLoadError", () => {
   })
 })
 
+const chunkError = () => {
+  const e = new Error("Failed to load chunk x")
+  e.name = "ChunkLoadError"
+  return e
+}
+
 describe("recoverFromChunkError", () => {
+  const reload = vi.fn()
+  let store: Record<string, string>
+  let throwOnStorage: boolean
+
+  beforeEach(() => {
+    store = {}
+    throwOnStorage = false
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"))
+    reload.mockClear()
+    ;(globalThis as { window?: unknown }).window = {
+      location: { reload },
+      sessionStorage: {
+        getItem: (k: string) => {
+          if (throwOnStorage) throw new Error("SecurityError")
+          return k in store ? store[k] : null
+        },
+        setItem: (k: string, v: string) => {
+          if (throwOnStorage) throw new Error("SecurityError")
+          store[k] = v
+        },
+      },
+    }
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    delete (globalThis as { window?: unknown }).window
+  })
+
+  // Simulate the browser actually reloading: a fresh window loses the in-memory flag,
+  // but same-origin sessionStorage persists.
+  const simulateReload = () => {
+    delete (globalThis.window as { __play14ChunkReloaded?: boolean }).__play14ChunkReloaded
+  }
+
+  it("reloads once on a chunk error and guards rapid repeats", () => {
+    expect(recoverFromChunkError(chunkError())).toBe(true)
+    expect(reload).toHaveBeenCalledTimes(1)
+    // A second chunk error within the same page load must NOT reload (no loop).
+    expect(recoverFromChunkError(chunkError())).toBe(false)
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  it("reloads again once the guard window elapses on a fresh page load", () => {
+    expect(recoverFromChunkError(chunkError())).toBe(true)
+    simulateReload()
+    vi.advanceTimersByTime(11_000)
+    expect(recoverFromChunkError(chunkError())).toBe(true)
+    expect(reload).toHaveBeenCalledTimes(2)
+  })
+
+  it("still reloads but cannot loop when sessionStorage is inaccessible", () => {
+    throwOnStorage = true
+    // First chunk error: storage read throws → in-memory backstop lets it reload once.
+    expect(recoverFromChunkError(chunkError())).toBe(true)
+    expect(reload).toHaveBeenCalledTimes(1)
+    // Same page load: the in-memory flag prevents a second reload despite broken storage.
+    expect(recoverFromChunkError(chunkError())).toBe(false)
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  it("does nothing for a non-chunk error", () => {
+    expect(recoverFromChunkError(new Error("nope"))).toBe(false)
+    expect(reload).not.toHaveBeenCalled()
+  })
+})
+
+describe("willRecoverFromChunkError", () => {
   const reload = vi.fn()
   let store: Record<string, string>
 
@@ -48,29 +123,14 @@ describe("recoverFromChunkError", () => {
     delete (globalThis as { window?: unknown }).window
   })
 
-  const chunkError = () => {
-    const e = new Error("Failed to load chunk x")
-    e.name = "ChunkLoadError"
-    return e
-  }
-
-  it("reloads once on a chunk error and guards rapid repeats", () => {
-    expect(recoverFromChunkError(chunkError())).toBe(true)
-    expect(reload).toHaveBeenCalledTimes(1)
-    // A second chunk error within the guard window must NOT reload (no loop).
-    expect(recoverFromChunkError(chunkError())).toBe(false)
-    expect(reload).toHaveBeenCalledTimes(1)
+  it("is true for a fresh chunk error and false once a reload is in flight", () => {
+    expect(willRecoverFromChunkError(chunkError())).toBe(true)
+    recoverFromChunkError(chunkError())
+    // Guard is now active → the boundary must NOT show the reloading spinner again.
+    expect(willRecoverFromChunkError(chunkError())).toBe(false)
   })
 
-  it("reloads again once the guard window elapses", () => {
-    expect(recoverFromChunkError(chunkError())).toBe(true)
-    vi.advanceTimersByTime(11_000)
-    expect(recoverFromChunkError(chunkError())).toBe(true)
-    expect(reload).toHaveBeenCalledTimes(2)
-  })
-
-  it("does nothing for a non-chunk error", () => {
-    expect(recoverFromChunkError(new Error("nope"))).toBe(false)
-    expect(reload).not.toHaveBeenCalled()
+  it("is false for a non-chunk error", () => {
+    expect(willRecoverFromChunkError(new Error("nope"))).toBe(false)
   })
 })

--- a/packages/web/src/libs/chunk-error.test.ts
+++ b/packages/web/src/libs/chunk-error.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { isChunkLoadError, recoverFromChunkError } from "./chunk-error"
+
+describe("isChunkLoadError", () => {
+  it("matches by error name", () => {
+    const e = new Error("boom")
+    e.name = "ChunkLoadError"
+    expect(isChunkLoadError(e)).toBe(true)
+  })
+
+  it("matches by message", () => {
+    expect(isChunkLoadError(new Error("Failed to load chunk /_next/static/chunks/abc.js"))).toBe(
+      true
+    )
+    expect(isChunkLoadError(new Error("Loading chunk 123 failed"))).toBe(true)
+    expect(isChunkLoadError(new Error("Loading CSS chunk 5 failed"))).toBe(true)
+  })
+
+  it("ignores unrelated and nullish errors", () => {
+    expect(isChunkLoadError(new Error("network down"))).toBe(false)
+    expect(isChunkLoadError(null)).toBe(false)
+    expect(isChunkLoadError(undefined)).toBe(false)
+  })
+})
+
+describe("recoverFromChunkError", () => {
+  const reload = vi.fn()
+  let store: Record<string, string>
+
+  beforeEach(() => {
+    store = {}
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"))
+    reload.mockClear()
+    ;(globalThis as { window?: unknown }).window = {
+      location: { reload },
+      sessionStorage: {
+        getItem: (k: string) => (k in store ? store[k] : null),
+        setItem: (k: string, v: string) => {
+          store[k] = v
+        },
+      },
+    }
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    delete (globalThis as { window?: unknown }).window
+  })
+
+  const chunkError = () => {
+    const e = new Error("Failed to load chunk x")
+    e.name = "ChunkLoadError"
+    return e
+  }
+
+  it("reloads once on a chunk error and guards rapid repeats", () => {
+    expect(recoverFromChunkError(chunkError())).toBe(true)
+    expect(reload).toHaveBeenCalledTimes(1)
+    // A second chunk error within the guard window must NOT reload (no loop).
+    expect(recoverFromChunkError(chunkError())).toBe(false)
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  it("reloads again once the guard window elapses", () => {
+    expect(recoverFromChunkError(chunkError())).toBe(true)
+    vi.advanceTimersByTime(11_000)
+    expect(recoverFromChunkError(chunkError())).toBe(true)
+    expect(reload).toHaveBeenCalledTimes(2)
+  })
+
+  it("does nothing for a non-chunk error", () => {
+    expect(recoverFromChunkError(new Error("nope"))).toBe(false)
+    expect(reload).not.toHaveBeenCalled()
+  })
+})

--- a/packages/web/src/libs/chunk-error.test.ts
+++ b/packages/web/src/libs/chunk-error.test.ts
@@ -29,28 +29,31 @@ const chunkError = () => {
   return e
 }
 
+const BASE_URL = "https://staging.play14.org/admin/players/abc"
+
 describe("recoverFromChunkError", () => {
+  const replace = vi.fn()
   const reload = vi.fn()
-  let store: Record<string, string>
-  let throwOnStorage: boolean
+  let href: string
 
   beforeEach(() => {
-    store = {}
-    throwOnStorage = false
+    href = BASE_URL
     vi.useFakeTimers()
     vi.setSystemTime(new Date("2026-01-01T00:00:00Z"))
-    reload.mockClear()
+    replace.mockReset().mockImplementation((u: string) => {
+      href = u // simulate the navigation updating the address bar
+    })
+    reload.mockReset()
     ;(globalThis as { window?: unknown }).window = {
-      location: { reload },
-      sessionStorage: {
-        getItem: (k: string) => {
-          if (throwOnStorage) throw new Error("SecurityError")
-          return k in store ? store[k] : null
+      location: {
+        get href() {
+          return href
         },
-        setItem: (k: string, v: string) => {
-          if (throwOnStorage) throw new Error("SecurityError")
-          store[k] = v
+        get search() {
+          return new URL(href).search
         },
+        replace,
+        reload,
       },
     }
   })
@@ -60,60 +63,64 @@ describe("recoverFromChunkError", () => {
     delete (globalThis as { window?: unknown }).window
   })
 
-  // Simulate the browser actually reloading: a fresh window loses the in-memory flag,
-  // but same-origin sessionStorage persists.
+  // A real reload starts a fresh window (in-memory flag gone) but keeps the URL — model that.
   const simulateReload = () => {
     delete (globalThis.window as { __play14ChunkReloaded?: boolean }).__play14ChunkReloaded
   }
 
-  it("reloads once on a chunk error and guards rapid repeats", () => {
+  it("reloads once on a chunk error and guards same-page repeats", () => {
     expect(recoverFromChunkError(chunkError())).toBe(true)
-    expect(reload).toHaveBeenCalledTimes(1)
+    expect(replace).toHaveBeenCalledTimes(1)
+    expect(href).toContain("_chunkReload=")
     // A second chunk error within the same page load must NOT reload (no loop).
     expect(recoverFromChunkError(chunkError())).toBe(false)
-    expect(reload).toHaveBeenCalledTimes(1)
+    expect(replace).toHaveBeenCalledTimes(1)
   })
 
-  it("reloads again once the guard window elapses on a fresh page load", () => {
+  it("breaks the loop after one reload even with no storage (URL marker survives)", () => {
+    expect(recoverFromChunkError(chunkError())).toBe(true)
+    // Fresh page load after the reload: in-memory flag is gone, but the URL marker remains.
+    simulateReload()
+    // The chunk is still missing (broken deploy) — recovery must give up, not loop.
+    expect(recoverFromChunkError(chunkError())).toBe(false)
+    expect(replace).toHaveBeenCalledTimes(1)
+  })
+
+  it("allows recovery again once the marker goes stale", () => {
     expect(recoverFromChunkError(chunkError())).toBe(true)
     simulateReload()
     vi.advanceTimersByTime(11_000)
     expect(recoverFromChunkError(chunkError())).toBe(true)
-    expect(reload).toHaveBeenCalledTimes(2)
-  })
-
-  it("still reloads but cannot loop when sessionStorage is inaccessible", () => {
-    throwOnStorage = true
-    // First chunk error: storage read throws → in-memory backstop lets it reload once.
-    expect(recoverFromChunkError(chunkError())).toBe(true)
-    expect(reload).toHaveBeenCalledTimes(1)
-    // Same page load: the in-memory flag prevents a second reload despite broken storage.
-    expect(recoverFromChunkError(chunkError())).toBe(false)
-    expect(reload).toHaveBeenCalledTimes(1)
+    expect(replace).toHaveBeenCalledTimes(2)
   })
 
   it("does nothing for a non-chunk error", () => {
     expect(recoverFromChunkError(new Error("nope"))).toBe(false)
-    expect(reload).not.toHaveBeenCalled()
+    expect(replace).not.toHaveBeenCalled()
   })
 })
 
 describe("willRecoverFromChunkError", () => {
-  const reload = vi.fn()
-  let store: Record<string, string>
+  const replace = vi.fn()
+  let href: string
 
   beforeEach(() => {
-    store = {}
+    href = BASE_URL
     vi.useFakeTimers()
     vi.setSystemTime(new Date("2026-01-01T00:00:00Z"))
-    reload.mockClear()
+    replace.mockReset().mockImplementation((u: string) => {
+      href = u
+    })
     ;(globalThis as { window?: unknown }).window = {
-      location: { reload },
-      sessionStorage: {
-        getItem: (k: string) => (k in store ? store[k] : null),
-        setItem: (k: string, v: string) => {
-          store[k] = v
+      location: {
+        get href() {
+          return href
         },
+        get search() {
+          return new URL(href).search
+        },
+        replace,
+        reload: vi.fn(),
       },
     }
   })

--- a/packages/web/src/libs/chunk-error.ts
+++ b/packages/web/src/libs/chunk-error.ts
@@ -1,0 +1,44 @@
+/**
+ * Helpers for recovering from stale-chunk errors after a deployment.
+ *
+ * When the app is redeployed, its JS chunks get new content hashes and the old
+ * files are removed. A browser tab that loaded the app before the deploy still
+ * references the old chunk names, so the next client-side navigation throws a
+ * `ChunkLoadError` ("Failed to load chunk …"). This is unavoidable in any
+ * long-lived SPA — the fix is to detect it and reload once, which fetches fresh
+ * HTML pointing at the current chunks.
+ */
+
+/** True when an error is a failed dynamic-chunk/CSS load (stale build after deploy). */
+export function isChunkLoadError(error: unknown): boolean {
+  if (!error) return false
+  const { name, message } = error as { name?: string; message?: string }
+  if (name === "ChunkLoadError") return true
+  return /Loading( CSS)? chunk [\w-]+ failed|Failed to load chunk/i.test(message ?? "")
+}
+
+const RELOAD_GUARD_KEY = "play14:chunk-reload-at"
+/** Don't auto-reload more than once per window — if the chunk is truly gone, show the error. */
+const RELOAD_GUARD_MS = 10_000
+
+/**
+ * If `error` is a stale-chunk error, force a single full reload to pick up the
+ * current build. Returns `true` when a reload was triggered so the caller can
+ * render a neutral placeholder instead of an error UI. Guarded by sessionStorage
+ * so a genuinely-missing chunk can't cause an infinite reload loop.
+ */
+export function recoverFromChunkError(error: unknown): boolean {
+  if (typeof window === "undefined" || !isChunkLoadError(error)) return false
+
+  try {
+    const last = Number(window.sessionStorage.getItem(RELOAD_GUARD_KEY) ?? "0")
+    if (Date.now() - last < RELOAD_GUARD_MS) return false
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()))
+  } catch {
+    // sessionStorage unavailable (private mode / disabled) — reload anyway; the
+    // worst case is the browser's own back-stop against reload loops.
+  }
+
+  window.location.reload()
+  return true
+}

--- a/packages/web/src/libs/chunk-error.ts
+++ b/packages/web/src/libs/chunk-error.ts
@@ -17,23 +17,34 @@ export function isChunkLoadError(error: unknown): boolean {
   return /Loading( CSS)? chunk [\w-]+ failed|Failed to load chunk/i.test(message ?? "")
 }
 
-const RELOAD_GUARD_KEY = "play14:chunk-reload-at"
-/** Don't auto-reload more than once per window — if the chunk is truly gone, show the error. */
+/** Query-param marker carried across the reload so the guard works without storage. */
+const RELOAD_PARAM = "_chunkReload"
+/** After this long the marker is treated as stale, so a later genuine error can recover. */
 const RELOAD_GUARD_MS = 10_000
 /** Per-page-load flag; a real reload starts a fresh window so it naturally resets. */
 type GuardedWindow = Window & { __play14ChunkReloaded?: boolean }
 
-/** True if a reload happened recently (within this page load OR the guard window). */
+/** Timestamp of the reload that produced the current page, from the URL marker (0 if none). */
+function reloadMarkerTimestamp(): number {
+  try {
+    const value = new URLSearchParams(window.location.search).get(RELOAD_PARAM)
+    return value ? Number(value) : 0
+  } catch {
+    return 0
+  }
+}
+
+/**
+ * True if we already auto-reloaded recently. Uses an in-memory flag for the
+ * current page load AND a URL-param timestamp that survives the reload. The URL
+ * marker is deliberately NOT sessionStorage: in sandboxed iframes / strict
+ * privacy modes storage throws, and a storage-only guard would let a
+ * genuinely-missing chunk reload forever. The marker caps it at one reload.
+ */
 function reloadGuardActive(): boolean {
   if ((window as GuardedWindow).__play14ChunkReloaded) return true
-  try {
-    const last = Number(window.sessionStorage.getItem(RELOAD_GUARD_KEY) ?? "0")
-    return Date.now() - last < RELOAD_GUARD_MS
-  } catch {
-    // sessionStorage inaccessible (SecurityError in sandboxed/strict contexts) — fall back
-    // to the in-memory flag above, which still prevents a same-page-load reload loop.
-    return false
-  }
+  const markerTs = reloadMarkerTimestamp()
+  return markerTs > 0 && Date.now() - markerTs < RELOAD_GUARD_MS
 }
 
 /**
@@ -50,21 +61,26 @@ export function willRecoverFromChunkError(error: unknown): boolean {
  * If `error` is a stale-chunk error and we haven't just reloaded, force a single
  * full reload to pick up the current build. Returns `true` when a reload was
  * triggered so the caller can render a neutral placeholder instead of an error
- * UI. Guarded two ways so it can't loop: an in-memory flag (survives even when
- * storage is blocked) and a sessionStorage timestamp (survives across reloads).
+ * UI. The reload carries a timestamped URL marker so the guard survives the
+ * reload without depending on (possibly-blocked) storage — a genuinely-missing
+ * chunk therefore reloads at most once instead of looping.
  */
 export function recoverFromChunkError(error: unknown): boolean {
   if (!willRecoverFromChunkError(error))
     return false
 
-    // Set the in-memory flag first so a blocked sessionStorage can't cause a loop.
+    // In-memory flag guards against a same-page-load double reload (e.g. React
+    // StrictMode re-running the effect, or multiple boundaries catching the same error).
   ;(window as GuardedWindow).__play14ChunkReloaded = true
-  try {
-    window.sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()))
-  } catch {
-    // Best effort — the in-memory flag is the backstop within this page load.
-  }
 
-  window.location.reload()
+  try {
+    const url = new URL(window.location.href)
+    url.searchParams.set(RELOAD_PARAM, String(Date.now()))
+    // replace() — don't add a history entry for the reload.
+    window.location.replace(url.toString())
+  } catch {
+    // URL API unavailable — fall back to a plain reload (in-memory flag still applies).
+    window.location.reload()
+  }
   return true
 }

--- a/packages/web/src/libs/chunk-error.ts
+++ b/packages/web/src/libs/chunk-error.ts
@@ -20,23 +20,49 @@ export function isChunkLoadError(error: unknown): boolean {
 const RELOAD_GUARD_KEY = "play14:chunk-reload-at"
 /** Don't auto-reload more than once per window — if the chunk is truly gone, show the error. */
 const RELOAD_GUARD_MS = 10_000
+/** Per-page-load flag; a real reload starts a fresh window so it naturally resets. */
+type GuardedWindow = Window & { __play14ChunkReloaded?: boolean }
 
-/**
- * If `error` is a stale-chunk error, force a single full reload to pick up the
- * current build. Returns `true` when a reload was triggered so the caller can
- * render a neutral placeholder instead of an error UI. Guarded by sessionStorage
- * so a genuinely-missing chunk can't cause an infinite reload loop.
- */
-export function recoverFromChunkError(error: unknown): boolean {
-  if (typeof window === "undefined" || !isChunkLoadError(error)) return false
-
+/** True if a reload happened recently (within this page load OR the guard window). */
+function reloadGuardActive(): boolean {
+  if ((window as GuardedWindow).__play14ChunkReloaded) return true
   try {
     const last = Number(window.sessionStorage.getItem(RELOAD_GUARD_KEY) ?? "0")
-    if (Date.now() - last < RELOAD_GUARD_MS) return false
+    return Date.now() - last < RELOAD_GUARD_MS
+  } catch {
+    // sessionStorage inaccessible (SecurityError in sandboxed/strict contexts) — fall back
+    // to the in-memory flag above, which still prevents a same-page-load reload loop.
+    return false
+  }
+}
+
+/**
+ * Whether `recoverFromChunkError` would reload for this error: a stale-chunk
+ * error that isn't already within the reload guard. Pure (no side effects), so
+ * an error boundary can use it to decide its initial render without flashing.
+ */
+export function willRecoverFromChunkError(error: unknown): boolean {
+  if (typeof window === "undefined" || !isChunkLoadError(error)) return false
+  return !reloadGuardActive()
+}
+
+/**
+ * If `error` is a stale-chunk error and we haven't just reloaded, force a single
+ * full reload to pick up the current build. Returns `true` when a reload was
+ * triggered so the caller can render a neutral placeholder instead of an error
+ * UI. Guarded two ways so it can't loop: an in-memory flag (survives even when
+ * storage is blocked) and a sessionStorage timestamp (survives across reloads).
+ */
+export function recoverFromChunkError(error: unknown): boolean {
+  if (!willRecoverFromChunkError(error))
+    return false
+
+    // Set the in-memory flag first so a blocked sessionStorage can't cause a loop.
+  ;(window as GuardedWindow).__play14ChunkReloaded = true
+  try {
     window.sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()))
   } catch {
-    // sessionStorage unavailable (private mode / disabled) — reload anyway; the
-    // worst case is the browser's own back-stop against reload loops.
+    // Best effort — the in-memory flag is the backstop within this page load.
   }
 
   window.location.reload()

--- a/packages/web/src/libs/connection-error.test.ts
+++ b/packages/web/src/libs/connection-error.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest"
+import { isConnectionError } from "./connection-error"
+
+describe("isConnectionError", () => {
+  it("matches transient network failures by message", () => {
+    expect(isConnectionError(new Error("fetch failed"))).toBe(true)
+    expect(isConnectionError(new Error("connect ECONNREFUSED 127.0.0.1:1337"))).toBe(true)
+    expect(isConnectionError(new Error("ECONNABORTED"))).toBe(true)
+  })
+
+  it("matches ECONNRESET via the error cause", () => {
+    const e = Object.assign(new Error("request failed"), { cause: { code: "ECONNRESET" } })
+    expect(isConnectionError(e)).toBe(true)
+  })
+
+  it("ignores application errors and nullish input", () => {
+    expect(isConnectionError(new Error("Validation error: Invalid status"))).toBe(false)
+    expect(isConnectionError(null)).toBe(false)
+    expect(isConnectionError(undefined)).toBe(false)
+  })
+})

--- a/packages/web/src/libs/connection-error.ts
+++ b/packages/web/src/libs/connection-error.ts
@@ -1,0 +1,16 @@
+/**
+ * True for transient network/connection failures (the API server is unreachable),
+ * as opposed to genuine application errors. Error boundaries use this to show a
+ * "server unavailable" message and suppress the bug-report link — a dropped
+ * connection isn't a bug to file.
+ */
+export function isConnectionError(error: unknown): boolean {
+  const e = error as { message?: string; cause?: { code?: string } } | null | undefined
+  const message = e?.message ?? ""
+  return (
+    message.includes("fetch failed") ||
+    e?.cause?.code === "ECONNRESET" ||
+    message.includes("ECONNREFUSED") ||
+    message.includes("ECONNABORTED")
+  )
+}


### PR DESCRIPTION
## Problem

Clicking around the admin UI on staging intermittently showed a bare **"Something went wrong"** page, with `ChunkLoadError: Failed to load chunk …` in the console. A hard refresh fixed it.

Two root causes:

1. **Stale chunks after deploy.** When the app is redeployed, JS chunks get new content hashes and the old files are removed. A tab loaded before the deploy still references the old chunk names, so the next client-side navigation throws `ChunkLoadError`. Staging redeploys on **every PR push**, so this reproduced reliably. This is unpreventable in principle for an already-open SPA — it has to be recovered from.
2. **No admin error boundary.** The `(admin)` route group had no `error.tsx`, so any error there bubbled up to `global-error.tsx` — a deliberately bare, unstyled fallback (it renders its own `<html>` outside the next-intl provider). That's why it didn't look like the #play14 error page.

## Changes

- **`libs/chunk-error.ts`** — `isChunkLoadError()` + `recoverFromChunkError()` (forces a single full reload to pick up the current build; `sessionStorage`-guarded so a genuinely-missing chunk can't loop).
- **`hooks/use-chunk-error-recovery.ts`** — shared hook for error boundaries: auto-reload on a chunk error, otherwise log + surface the error normally.
- **`[locale]/(admin)/error.tsx`** (new) — styled #play14 error UI for the admin section (mirrors `(main)/error.tsx`), instead of falling through to the bare global page. Self-heals chunk errors.
- Wired the same recovery into **`(main)/error.tsx`** and **`global-error.tsx`** so the whole app self-heals after deploys.

After this, a stale-chunk navigation transparently reloads to the fresh build; users no longer see an error page for it, and any genuine admin error renders the styled page.

## Verification
- Web typecheck ✅ · Biome ✅ · **280 web tests pass** (274 + 6 new `chunk-error` specs covering the matcher and the reload/guard logic).

## Notes
- Independent of #157 (create-player) — this is a pre-existing error-boundary gap surfaced while testing that feature. Reviewed/branched off `main`.
- Doesn't change the staging deploy cadence; it makes the client resilient to it. If we later want to reduce *how often* skew happens, that's a separate infra conversation (e.g. CDN cache headers, instance/build consistency).