### PR TITLE
fix: event translation for Italian and Portuguese, and a clear quota message

### DIFF
--- a/packages/api/src/api/translate/controllers/translate.test.ts
+++ b/packages/api/src/api/translate/controllers/translate.test.ts
@@ -1,0 +1,40 @@
+import { readdirSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+import { LOCALE_NAMES } from "./translate"
+
+const here = dirname(fileURLToPath(import.meta.url))
+const MESSAGES_DIR = resolve(here, "../../../../../web/messages")
+
+function webLocales(): string[] {
+  return readdirSync(MESSAGES_DIR)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => file.replace(/\.json$/, ""))
+    .sort()
+}
+
+describe("LOCALE_NAMES", () => {
+  // Reads the real message files rather than a copied list, so adding a locale
+  // to the web app fails here instead of silently degrading translation.
+  it("covers every locale the web app ships", () => {
+    expect(Object.keys(LOCALE_NAMES).sort()).toEqual(webLocales())
+  })
+
+  it("maps each locale to a language name, never back to the bare code", () => {
+    for (const [locale, name] of Object.entries(LOCALE_NAMES)) {
+      expect(name).not.toBe(locale)
+      expect(name.length).toBeGreaterThan(locale.length)
+    }
+  })
+
+  it("names Italian explicitly", () => {
+    // Regression guard: "it" was missing, so the prompt read "translate from
+    // English to it" — indistinguishable from the English pronoun.
+    expect(LOCALE_NAMES.it).toBe("Italian")
+  })
+
+  it("names Portuguese explicitly", () => {
+    expect(LOCALE_NAMES.pt).toBe("Portuguese")
+  })
+})

--- a/packages/api/src/api/translate/controllers/translate.test.ts
+++ b/packages/api/src/api/translate/controllers/translate.test.ts
@@ -2,7 +2,7 @@ import { readdirSync } from "node:fs"
 import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { describe, expect, it } from "vitest"
-import { LOCALE_NAMES } from "./translate"
+import { isQuotaExhausted, LOCALE_NAMES } from "./translate"
 
 const here = dirname(fileURLToPath(import.meta.url))
 const MESSAGES_DIR = resolve(here, "../../../../../web/messages")
@@ -36,5 +36,26 @@ describe("LOCALE_NAMES", () => {
 
   it("names Portuguese explicitly", () => {
     expect(LOCALE_NAMES.pt).toBe("Portuguese")
+  })
+})
+
+describe("isQuotaExhausted", () => {
+  // Real shapes the @google/generative-ai SDK surfaces for a spent free tier.
+  it.each([
+    "[GoogleGenerativeAI Error]: Error fetching from https://generativelanguage.googleapis.com: [429 Too Many Requests]",
+    "429 RESOURCE_EXHAUSTED: Quota exceeded for quota metric 'Generate requests'",
+    "You exceeded your current quota, please check your plan and billing details",
+    "Resource has been exhausted (e.g. check quota)",
+  ])("recognises %s", (message) => {
+    expect(isQuotaExhausted(message)).toBe(true)
+  })
+
+  it.each([
+    "Translation timed out",
+    "[GoogleGenerativeAI Error]: [400 Bad Request] Invalid JSON payload",
+    "fetch failed",
+    "[503 Service Unavailable] The model is overloaded",
+  ])("does not claim quota for %s", (message) => {
+    expect(isQuotaExhausted(message)).toBe(false)
   })
 })

--- a/packages/api/src/api/translate/controllers/translate.ts
+++ b/packages/api/src/api/translate/controllers/translate.ts
@@ -4,11 +4,19 @@
 
 import { GoogleGenerativeAI } from "@google/generative-ai"
 
-const LOCALE_NAMES: Record<string, string> = {
+/**
+ * Must list every locale in `packages/web/src/messages/`. A missing entry does
+ * not fail loudly — the code below falls back to the bare code, so the prompt
+ * became "translate from English to it", where "it" reads as the pronoun rather
+ * than Italian. Keep this in step when a locale is added.
+ */
+export const LOCALE_NAMES: Record<string, string> = {
   en: "English",
   fr: "French",
   es: "Spanish",
   de: "German",
+  it: "Italian",
+  pt: "Portuguese",
 }
 
 const DEFAULT_MODEL = "gemini-2.5-flash"

--- a/packages/api/src/api/translate/controllers/translate.ts
+++ b/packages/api/src/api/translate/controllers/translate.ts
@@ -22,6 +22,19 @@ export const LOCALE_NAMES: Record<string, string> = {
 const DEFAULT_MODEL = "gemini-2.5-flash"
 const GEMINI_TIMEOUT_MS = 60000
 
+/**
+ * Recognises Gemini's daily-quota rejection.
+ *
+ * The SDK surfaces it as a plain Error whose message carries the HTTP status
+ * and the API's status name, so string matching is the only option. Matched
+ * broadly on purpose: mistaking another 429 for a quota problem still tells the
+ * editor something true (too many requests, wait), whereas missing a real quota
+ * error puts them back to guessing at "Translation failed".
+ */
+export function isQuotaExhausted(message: string): boolean {
+  return /429|RESOURCE_EXHAUSTED|quota|rate.?limit/i.test(message)
+}
+
 async function withTimeout<T>(promise: Promise<T>): Promise<T> {
   let timeoutId: ReturnType<typeof setTimeout>
   const timeoutPromise = new Promise<never>((_, reject) => {
@@ -94,6 +107,22 @@ ${text}`,
       })
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
+
+      if (isQuotaExhausted(message)) {
+        // Gemini's free tier resets daily, so this is worth telling the editor
+        // apart from a genuine failure — they only need to come back tomorrow.
+        strapi.log.warn(`[Translate] Gemini quota exhausted: ${message}`)
+        ctx.status = 429
+        ctx.body = {
+          error: {
+            status: 429,
+            name: "QuotaExhaustedError",
+            message: "Daily translation quota reached",
+          },
+        }
+        return
+      }
+
       strapi.log.error("Translation error:", message)
       return ctx.internalServerError("Translation failed")
     }

--- a/packages/web/messages/de.json
+++ b/packages/web/messages/de.json
@@ -1474,7 +1474,10 @@
       "eventImages": "Veranstaltungsbilder",
       "eventImagesDescription": "Lade Bilder hoch, um deine Veranstaltung zu präsentieren. Füge ein Standardbild für Auflistungen und Galeriebilder für die Veranstaltungsseite hinzu.",
       "eventSchedule": "Veranstaltungszeitplan",
-      "eventScheduleDescription": "Definiere den tageweisen Zeitplan für deine Veranstaltung. Füge Zeitfenster mit Beschreibungen für jeden Tag hinzu."
+      "eventScheduleDescription": "Definiere den tageweisen Zeitplan für deine Veranstaltung. Füge Zeitfenster mit Beschreibungen für jeden Tag hinzu.",
+      "translationQuotaReached": "Tageslimit für Übersetzungen erreicht. Versuch es morgen wieder.",
+      "translationFailed": "Übersetzung fehlgeschlagen. Versuch es noch einmal.",
+      "translationNotAuthenticated": "Deine Sitzung ist abgelaufen. Melde dich erneut an, um zu übersetzen."
     },
     "translation": {
       "unsavedChangesWarning": "Du hast ungespeicherte Änderungen in dieser Sprache. Möchtest du sie speichern, bevor du wechselst?",

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -1916,7 +1916,10 @@
       "eventImages": "Event images",
       "eventImagesDescription": "Upload images to showcase your event. Add a default image for listings and gallery images for the event page.",
       "eventSchedule": "Event schedule",
-      "eventScheduleDescription": "Define the day-by-day schedule for your event. Add timeslots with descriptions for each day."
+      "eventScheduleDescription": "Define the day-by-day schedule for your event. Add timeslots with descriptions for each day.",
+      "translationQuotaReached": "Daily translation limit reached. Try again tomorrow.",
+      "translationFailed": "Translation failed. Please try again.",
+      "translationNotAuthenticated": "Your session expired. Sign in again to translate."
     },
     "translation": {
       "unsavedChangesWarning": "You have unsaved changes in this language. Do you want to save them before switching?",

--- a/packages/web/messages/es.json
+++ b/packages/web/messages/es.json
@@ -1916,7 +1916,10 @@
       "eventImages": "Imágenes del evento",
       "eventImagesDescription": "Sube imágenes para mostrar tu evento. Añade una imagen predeterminada para los listados e imágenes de galería para la página del evento.",
       "eventSchedule": "Horario del evento",
-      "eventScheduleDescription": "Define el horario día a día de tu evento. Añade franjas horarias con descripciones para cada día."
+      "eventScheduleDescription": "Define el horario día a día de tu evento. Añade franjas horarias con descripciones para cada día.",
+      "translationQuotaReached": "Has alcanzado el límite diario de traducción. Inténtalo mañana.",
+      "translationFailed": "La traducción ha fallado. Inténtalo de nuevo.",
+      "translationNotAuthenticated": "Tu sesión ha caducado. Vuelve a iniciar sesión para traducir."
     },
     "translation": {
       "unsavedChangesWarning": "Tienes cambios sin guardar en este idioma. ¿Quieres guardarlos antes de cambiar?",

--- a/packages/web/messages/fr.json
+++ b/packages/web/messages/fr.json
@@ -1916,7 +1916,10 @@
       "eventImages": "Images de l'événement",
       "eventImagesDescription": "Télécharge des images pour mettre en valeur ton événement. Ajoute une image par défaut pour les fiches et des images de galerie pour la page de l'événement.",
       "eventSchedule": "Programme de l'événement",
-      "eventScheduleDescription": "Définis le programme jour par jour de ton événement. Ajoute des créneaux horaires avec des descriptions pour chaque jour."
+      "eventScheduleDescription": "Définis le programme jour par jour de ton événement. Ajoute des créneaux horaires avec des descriptions pour chaque jour.",
+      "translationQuotaReached": "Limite de traduction quotidienne atteinte. Réessaie demain.",
+      "translationFailed": "La traduction a échoué. Réessaie.",
+      "translationNotAuthenticated": "Ta session a expiré. Reconnecte-toi pour traduire."
     },
     "translation": {
       "unsavedChangesWarning": "Tu as des modifications non enregistrées dans cette langue. Veux-tu les sauvegarder avant de changer?",

--- a/packages/web/messages/it.json
+++ b/packages/web/messages/it.json
@@ -1916,7 +1916,10 @@
       "eventImages": "Immagini evento",
       "eventImagesDescription": "Carica immagini per presentare il tuo evento. Aggiungi un'immagine predefinita per gli elenchi e immagini della galleria per la pagina evento.",
       "eventSchedule": "Programma evento",
-      "eventScheduleDescription": "Definisci il programma giorno per giorno del tuo evento. Aggiungi fasce orarie con descrizioni per ogni giorno."
+      "eventScheduleDescription": "Definisci il programma giorno per giorno del tuo evento. Aggiungi fasce orarie con descrizioni per ogni giorno.",
+      "translationQuotaReached": "Hai raggiunto il limite giornaliero di traduzione. Riprova domani.",
+      "translationFailed": "Traduzione non riuscita. Riprova.",
+      "translationNotAuthenticated": "La tua sessione è scaduta. Accedi di nuovo per tradurre."
     },
     "translation": {
       "unsavedChangesWarning": "Hai modifiche non salvate in questa lingua. Vuoi salvarle prima di cambiare?",

--- a/packages/web/messages/pt.json
+++ b/packages/web/messages/pt.json
@@ -1916,7 +1916,10 @@
       "eventImages": "Imagens do evento",
       "eventImagesDescription": "Carrega imagens para dar destaque ao teu evento. Adiciona uma imagem por defeito para as listagens e imagens de galeria para a página do evento.",
       "eventSchedule": "Programa do evento",
-      "eventScheduleDescription": "Define o programa dia a dia do teu evento. Adiciona blocos horários com descrições para cada dia."
+      "eventScheduleDescription": "Define o programa dia a dia do teu evento. Adiciona blocos horários com descrições para cada dia.",
+      "translationQuotaReached": "Atingiste o limite diário de tradução. Tenta outra vez amanhã.",
+      "translationFailed": "A tradução falhou. Tenta outra vez.",
+      "translationNotAuthenticated": "A tua sessão expirou. Inicia sessão outra vez para traduzir."
     },
     "translation": {
       "unsavedChangesWarning": "Tens alterações por guardar neste idioma. Queres guardá-las antes de mudar?",

--- a/packages/web/src/app/[locale]/(admin)/admin/events/[slug]/event-translation.action.ts
+++ b/packages/web/src/app/[locale]/(admin)/admin/events/[slug]/event-translation.action.ts
@@ -81,8 +81,14 @@ export async function updateEventLocalization(
   }
 }
 
+/** Why a translation attempt did not produce text, for the UI to phrase. */
+export type TranslationFailure = "quota" | "unauthenticated" | "failed"
+
 /**
- * Translate description using Gemini
+ * Translate description using Gemini.
+ *
+ * Returns a `reason` rather than a message: the copy lives in the locale files,
+ * so a server action must not decide the wording.
  */
 export async function translateWithGemini(
   text: string,
@@ -92,7 +98,7 @@ export async function translateWithGemini(
   const token = await getAuthCookie()
 
   if (!token) {
-    return { success: false, error: "Not authenticated" as const }
+    return { success: false, reason: "unauthenticated" as const }
   }
 
   try {
@@ -111,15 +117,22 @@ export async function translateWithGemini(
     })
 
     if (!response.ok) {
-      const errorData = await response.json()
+      const errorData = await response.json().catch(() => null)
       console.error("Translation error:", errorData)
-      return { success: false, error: "Translation failed" as const }
+
+      // The daily Gemini quota is the one failure an editor can act on, so it
+      // gets its own reason rather than being flattened into "failed".
+      if (response.status === 429 || errorData?.error?.name === "QuotaExhaustedError") {
+        return { success: false, reason: "quota" as const }
+      }
+
+      return { success: false, reason: "failed" as const }
     }
 
     const data = await response.json()
     return { success: true, translation: data.translation as string }
   } catch (error) {
     console.error("Error translating:", error)
-    return { success: false, error: "Translation failed" as const }
+    return { success: false, reason: "failed" as const }
   }
 }

--- a/packages/web/src/app/[locale]/(admin)/admin/events/[slug]/tabs/content-tab.tsx
+++ b/packages/web/src/app/[locale]/(admin)/admin/events/[slug]/tabs/content-tab.tsx
@@ -90,7 +90,14 @@ export default function ContentTab({
           }
         }
       } else {
-        toast.error(result.error || "Translation failed")
+        // The daily quota is the one outcome the editor can act on, so it gets
+        // its own message instead of a generic failure.
+        const messages = {
+          quota: t("translationQuotaReached"),
+          unauthenticated: t("translationNotAuthenticated"),
+          failed: t("translationFailed"),
+        } as const
+        toast.error(messages[result.reason ?? "failed"])
       }
     } finally {
       setIsTranslating(false)

--- a/packages/web/src/app/[locale]/layout.tsx
+++ b/packages/web/src/app/[locale]/layout.tsx
@@ -4,7 +4,7 @@ import { hasLocale, NextIntlClientProvider } from "next-intl"
 import { getTranslations, setRequestLocale } from "next-intl/server"
 import NextTopLoader from "nextjs-toploader"
 import ScrollToTop from "@/components/utils/scroll-to-top"
-import { routing } from "@/i18n/routing"
+import { ogLocales, routing } from "@/i18n/routing"
 
 type Props = {
   children: React.ReactNode
@@ -45,13 +45,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
           alt: "play14 logo transparent background",
         },
       ],
-      locale:
-        (
-          { en: "en_US", fr: "fr_FR", es: "es_ES", de: "de_DE", it: "it_IT" } as Record<
-            string,
-            string
-          >
-        )[locale] || "en_US",
+      locale: ogLocales[locale] || "en_US",
       type: "website",
     },
     alternates: {

--- a/packages/web/src/i18n/routing.test.ts
+++ b/packages/web/src/i18n/routing.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import { localeLabels, localeShortLabels, ogLocales, routing } from "./routing"
+
+/**
+ * Every locale map has to cover every configured locale. These drift silently:
+ * a missing key falls back to English rather than throwing, so Portuguese pages
+ * shipped `og:locale: en_US` for as long as `pt` was absent from that map.
+ */
+const MAPS = {
+  localeLabels,
+  localeShortLabels,
+  ogLocales,
+} as const
+
+describe("locale maps", () => {
+  for (const [name, map] of Object.entries(MAPS)) {
+    it(`${name} covers exactly routing.locales`, () => {
+      expect(Object.keys(map).sort()).toEqual([...routing.locales].sort())
+    })
+
+    it(`${name} has no empty values`, () => {
+      for (const [locale, value] of Object.entries(map)) {
+        expect(value, `${name}.${locale}`).toBeTruthy()
+      }
+    })
+  }
+
+  it("ships the six locales the message files provide", () => {
+    expect([...routing.locales].sort()).toEqual(["de", "en", "es", "fr", "it", "pt"])
+  })
+
+  it("maps Italian and Portuguese to their own OpenGraph locales", () => {
+    // Regression guard: both previously fell through to en_US.
+    expect(ogLocales.it).toBe("it_IT")
+    expect(ogLocales.pt).toBe("pt_PT")
+  })
+})

--- a/packages/web/src/i18n/routing.ts
+++ b/packages/web/src/i18n/routing.ts
@@ -25,3 +25,17 @@ export const localeShortLabels: Record<string, string> = {
   it: "IT",
   pt: "PT",
 }
+
+/**
+ * OpenGraph `og:locale` values. Lives here with the other locale maps so it is
+ * updated alongside them — it previously sat inline in the root layout and had
+ * already drifted, leaving Portuguese pages advertising themselves as en_US.
+ */
+export const ogLocales: Record<string, string> = {
+  en: "en_US",
+  fr: "fr_FR",
+  es: "es_ES",
+  de: "de_DE",
+  it: "it_IT",
+  pt: "pt_PT",
+}


### PR DESCRIPTION
## What

Two bugs in event content translation, plus the reason the second one was so hard to diagnose.

| commit | what |
| --- | --- |
| `e1706c0` | add the missing `it` and `pt` locales to the translation prompt |
| `c0d8d95` | tell editors when the daily translation quota is spent |

Gemini stays as the provider — no dependency or provider changes.

---

## 1. Italian and Portuguese were never named to the model

`LOCALE_NAMES` in the translate controller listed only `en`, `fr`, `es` and `de`, while the web app ships six locales. The lookup falls back to the bare locale code, so it never failed loudly — it just sent a worse prompt:

```
Translate the following text from English to it.
```

`it` reads as the English pronoun rather than the language. Portuguese had the same gap, less ambiguously. Both are now named.

The regression test reads `packages/web/messages/` directly rather than duplicating the locale list, so adding a seventh locale to the web app fails here instead of silently degrading translation. Confirmed it actually catches the bug: removing `it` again turns two tests red.

## 2. An exhausted quota looked like every other failure

This is what made the outage take a debugging session rather than a glance. An exhausted Gemini quota was indistinguishable from a malformed payload or an expired session, because the message was swallowed three times over:

- the controller collapsed every error into a 500 `"Translation failed"`;
- the server action then discarded even that and returned its own hardcoded `"Translation failed"`;
- the toast printed whatever it was handed.

The only way to learn the real cause was to read server logs.

Now it travels end to end:

- **API** recognises Gemini's rejection and answers `429` with a `QuotaExhaustedError` envelope, matching the shape `middlewares/rate-limit.ts` already uses.
- **Server action** returns a `reason` discriminator (`quota` / `unauthenticated` / `failed`) instead of prose. Copy belongs in the locale files, not in a server action.
- **`content-tab.tsx`** maps the reason onto translated copy.

English reads **"Daily translation limit reached. Try again tomorrow."** The free tier resets daily, so that instruction is both actionable and true.

Detection matches broadly — `429`, `RESOURCE_EXHAUSTED`, `quota`, `rate limit`. A false positive still tells the editor something true (too many requests, wait), while a false negative puts them back to guessing. Eight cases cover both directions using the error strings the SDK actually produces.

## 3. A second locale-map gap, found while checking the first

Asked to make sure `it` and `pt` were handled everywhere, I swept for other locale maps. `app/[locale]/layout.tsx` carried an inline `og:locale` map that had drifted and was missing `pt` — so **Portuguese pages advertised themselves to crawlers and social platforms as `en_US`**.

That map now lives in `i18n/routing.ts` beside the other locale maps, and a test asserts all three cover `routing.locales` exactly with no empty values. This class of drift now fails a test rather than shipping. (`localeLabels` and `localeShortLabels` were already correct.)

## Copy

Three new keys in all six locale files, each in that locale's informal register (`de` du, `fr` tu, `es` tú, `it` tu, `pt` tu). `i18n-sync` reports 2036 keys per locale, zero missing, zero extra.

> [!NOTE]
> I wrote the five non-English strings myself rather than leaving `[TODO:]` placeholders — they're short and follow the documented conventions. Worth a native-speaker glance before merge, particularly the Portuguese, which is European form to match `pt_PT`.

## Verification

- `bun --filter play14-api test` — 550 tests
- `bun --filter play14-web test` — 288 tests
- both typechecks, `bun run check` (Biome) — clean
- `i18n-sync` — all six locales in sync

## Not included

The quota outage prompted a look at routing translation through the Vercel AI Gateway, with Cloudflare and Infomaniak evaluated as cheaper or free alternatives. That work is parked on `feat/ai-gateway-translation` and deliberately left out of this PR — none of it is needed to fix the bugs above.