### PR TITLE
fix(web): make the event sponsor picker usable again

### DIFF
--- a/packages/web/messages/de.json
+++ b/packages/web/messages/de.json
@@ -1804,7 +1804,11 @@
       "creating": "Erstellen...",
       "createSponsor": "Sponsor erstellen",
       "failedToCreate": "Fehler beim Erstellen des Sponsors",
-      "removeSponsor": "Sponsor entfernen"
+      "removeSponsor": "Sponsor entfernen",
+      "removeCategory": "Kategorie {category} entfernen",
+      "nameRequiredError": "Name ist erforderlich",
+      "duplicateHint": "Ein Sponsor namens „{name}“ existiert bereits.",
+      "useExisting": "Vorhandenen verwenden"
     },
     "finance": {
       "revenue": "Einnahmen",

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -2246,7 +2246,11 @@
       "creating": "Creating...",
       "createSponsor": "Create sponsor",
       "failedToCreate": "Failed to create sponsor",
-      "removeSponsor": "Remove sponsor"
+      "removeSponsor": "Remove sponsor",
+      "removeCategory": "Remove {category} category",
+      "nameRequiredError": "Name is required",
+      "duplicateHint": "A sponsor named “{name}” already exists.",
+      "useExisting": "Use the existing one"
     },
     "finance": {
       "revenue": "Revenue",

--- a/packages/web/messages/es.json
+++ b/packages/web/messages/es.json
@@ -2246,7 +2246,11 @@
       "creating": "Creando...",
       "createSponsor": "Crear patrocinador",
       "failedToCreate": "Error al crear el patrocinador",
-      "removeSponsor": "Eliminar patrocinador"
+      "removeSponsor": "Eliminar patrocinador",
+      "removeCategory": "Eliminar la categoría {category}",
+      "nameRequiredError": "El nombre es obligatorio",
+      "duplicateHint": "Ya existe un patrocinador llamado «{name}».",
+      "useExisting": "Usar el existente"
     },
     "finance": {
       "revenue": "Ingresos",

--- a/packages/web/messages/fr.json
+++ b/packages/web/messages/fr.json
@@ -2246,7 +2246,11 @@
       "creating": "Création...",
       "createSponsor": "Créer le sponsor",
       "failedToCreate": "Impossible de créer le sponsor",
-      "removeSponsor": "Retirer le sponsor"
+      "removeSponsor": "Retirer le sponsor",
+      "removeCategory": "Retirer la catégorie {category}",
+      "nameRequiredError": "Le nom est obligatoire",
+      "duplicateHint": "Un sponsor nommé « {name} » existe déjà.",
+      "useExisting": "Utiliser l’existant"
     },
     "finance": {
       "revenue": "Revenus",

--- a/packages/web/messages/it.json
+++ b/packages/web/messages/it.json
@@ -2246,7 +2246,11 @@
       "creating": "Creazione...",
       "createSponsor": "Crea sponsor",
       "failedToCreate": "Impossibile creare lo sponsor",
-      "removeSponsor": "Rimuovi sponsor"
+      "removeSponsor": "Rimuovi sponsor",
+      "removeCategory": "Rimuovi la categoria {category}",
+      "nameRequiredError": "Il nome è obbligatorio",
+      "duplicateHint": "Esiste già uno sponsor di nome “{name}”.",
+      "useExisting": "Usa quello esistente"
     },
     "finance": {
       "revenue": "Ricavi",

--- a/packages/web/messages/pt.json
+++ b/packages/web/messages/pt.json
@@ -2246,7 +2246,11 @@
       "creating": "A criar...",
       "createSponsor": "Criar patrocinador",
       "failedToCreate": "Não foi possível criar o patrocinador",
-      "removeSponsor": "Remover patrocinador"
+      "removeSponsor": "Remover patrocinador",
+      "removeCategory": "Remover a categoria {category}",
+      "nameRequiredError": "O nome é obrigatório",
+      "duplicateHint": "Já existe um patrocinador com o nome “{name}”.",
+      "useExisting": "Usar o existente"
     },
     "finance": {
       "revenue": "Receitas",

--- a/packages/web/src/app/[locale]/(admin)/admin/events/[slug]/sponsor.action.ts
+++ b/packages/web/src/app/[locale]/(admin)/admin/events/[slug]/sponsor.action.ts
@@ -38,27 +38,46 @@ export interface SponsorActionResult<T = void> {
  * Get all available sponsors for selection
  */
 export async function getAvailableSponsors(): Promise<SponsorActionResult<Sponsor[]>> {
-  // Fetch all sponsors with pagination disabled (limit -1 not supported, use large number)
-  const result = await strapiFetchWithQuery<{ data: Sponsor[] }>(
-    "/sponsors",
-    {},
-    {
-      sort: "name:asc",
-      populate: "logo",
-      "pagination[pageSize]": "1000",
-    }
-  )
+  // The API clamps pageSize to `api.rest.maxLimit` (100), so a single oversized
+  // page silently truncates the list and hides sponsors from the picker.
+  const PAGE_SIZE = 100
+  const MAX_PAGES = 50
+  const sponsors: Sponsor[] = []
 
-  if (!result.ok) {
-    return {
-      success: false,
-      error: result.error || "Failed to fetch sponsors",
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    const result = await strapiFetchWithQuery<{
+      data: Sponsor[]
+      meta?: { pagination?: { pageCount?: number } }
+    }>(
+      "/sponsors",
+      {},
+      {
+        sort: "name:asc",
+        populate: "logo",
+        "pagination[page]": String(page),
+        "pagination[pageSize]": String(PAGE_SIZE),
+      }
+    )
+
+    if (!result.ok) {
+      return {
+        success: false,
+        error: result.error || "Failed to fetch sponsors",
+      }
+    }
+
+    const batch = result.data?.data || []
+    sponsors.push(...batch)
+
+    const pageCount = result.data?.meta?.pagination?.pageCount
+    if (batch.length < PAGE_SIZE || (pageCount !== undefined && page >= pageCount)) {
+      break
     }
   }
 
   return {
     success: true,
-    data: result.data?.data || [],
+    data: sponsors,
   }
 }
 

--- a/packages/web/src/app/[locale]/(admin)/admin/locations/create/location-create-form.tsx
+++ b/packages/web/src/app/[locale]/(admin)/admin/locations/create/location-create-form.tsx
@@ -24,13 +24,13 @@ export default function LocationCreateForm() {
     setIsSubmitting(true)
 
     if (!name.trim()) {
-      toast.error(t("adminCrud.common.nameRequired"))
+      toast.error(t("common.nameRequired"))
       setIsSubmitting(false)
       return
     }
 
     if (!country) {
-      toast.error(t("adminCrud.locations.form.selectCountry"))
+      toast.error(t("locations.form.selectCountry"))
       setIsSubmitting(false)
       return
     }
@@ -42,28 +42,23 @@ export default function LocationCreateForm() {
     })
 
     if (!result.success) {
-      toast.error(
-        result.error ||
-          t("adminCrud.common.failedToCreate", { entity: t("adminCrud.locations.entityName") })
-      )
+      toast.error(result.error || t("common.failedToCreate", { entity: t("locations.entityName") }))
       setIsSubmitting(false)
       return
     }
 
-    toast.success(
-      t("adminCrud.common.createdSuccess", { entity: t("adminCrud.locations.entityName") })
-    )
+    toast.success(t("common.createdSuccess", { entity: t("locations.entityName") }))
     router.push(`/admin/locations/${result.documentId}`)
   }
 
   return (
     <form onSubmit={handleSubmit} className="admin-form location-edit-form">
       <div className="admin-form-section">
-        <h2>{t("adminCrud.locations.form.detailsTitle")}</h2>
+        <h2>{t("locations.form.detailsTitle")}</h2>
 
         <div className="admin-form-row">
           <div className="admin-form-group">
-            <label htmlFor="name">{t("adminCrud.locations.form.nameLabel")}</label>
+            <label htmlFor="name">{t("locations.form.nameLabel")}</label>
             <input
               type="text"
               id="name"
@@ -72,19 +67,19 @@ export default function LocationCreateForm() {
               required
               minLength={2}
               className="admin-input"
-              placeholder={t("adminCrud.locations.form.namePlaceholder")}
+              placeholder={t("locations.form.namePlaceholder")}
             />
-            <p className="admin-form-help">{t("adminCrud.locations.form.nameHelp")}</p>
+            <p className="admin-form-help">{t("locations.form.nameHelp")}</p>
           </div>
         </div>
 
         <div className="admin-form-row">
           <div className="admin-form-group">
-            <label>{t("adminCrud.locations.form.countryLabel")}</label>
+            <label>{t("locations.form.countryLabel")}</label>
             <CountrySelector
               value={country}
               onChange={setCountry}
-              placeholder={t("adminCrud.locations.form.countryPlaceholder")}
+              placeholder={t("locations.form.countryPlaceholder")}
               required
             />
           </div>
@@ -92,10 +87,8 @@ export default function LocationCreateForm() {
       </div>
 
       <div className="admin-form-section">
-        <h2>{t("adminCrud.locations.form.mapTitle")}</h2>
-        <p className="admin-form-section-description">
-          {t("adminCrud.locations.form.mapDescription")}
-        </p>
+        <h2>{t("locations.form.mapTitle")}</h2>
+        <p className="admin-form-section-description">{t("locations.form.mapDescription")}</p>
 
         <div className="admin-form-row">
           <div className="admin-form-group full-width">
@@ -121,12 +114,12 @@ export default function LocationCreateForm() {
           {isSubmitting ? (
             <>
               <i className="bx bx-loader-alt bx-spin" />
-              {t("adminCrud.common.creating")}...
+              {t("common.creating")}
             </>
           ) : (
             <>
               <i className="bx bx-plus" />
-              {t("adminCrud.locations.create.submitButton")}
+              {t("locations.create.submitButton")}
             </>
           )}
         </button>

--- a/packages/web/src/components/admin/sponsor-editor.tsx
+++ b/packages/web/src/components/admin/sponsor-editor.tsx
@@ -19,6 +19,7 @@ interface Props {
 }
 
 export default function SponsorEditor({ sponsorships, onChange }: Props) {
+  const t = useTranslations("adminEvents.sponsorEditor")
   const [availableSponsors, setAvailableSponsors] = useState<Sponsor[]>([])
   const [_isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -98,7 +99,7 @@ export default function SponsorEditor({ sponsorships, onChange }: Props) {
       setCreateForCategory(null)
       return result.data
     }
-    setError(result.error || "Failed to create sponsor")
+    setError(result.error || t("failedToCreate"))
     return null
   }
 
@@ -127,7 +128,7 @@ export default function SponsorEditor({ sponsorships, onChange }: Props) {
                 type="button"
                 className="admin-btn-icon"
                 onClick={() => removeCategory(sponsorship.category)}
-                title={`Remove ${sponsorship.category} category`}
+                title={t("removeCategory", { category: sponsorship.category })}
               >
                 <i className="bx bx-trash" />
               </button>
@@ -152,7 +153,7 @@ export default function SponsorEditor({ sponsorships, onChange }: Props) {
                     onClick={() =>
                       removeSponsorFromCategory(sponsorship.category, sponsor.documentId)
                     }
-                    title="Remove sponsor"
+                    title={t("removeSponsor")}
                   >
                     <i className="bx bx-x" />
                   </button>
@@ -173,7 +174,7 @@ export default function SponsorEditor({ sponsorships, onChange }: Props) {
                   }
                 }}
               >
-                <option value="">Add sponsor...</option>
+                <option value="">{t("addSponsor")}</option>
                 {getUnusedSponsors().map((sponsor) => (
                   <option key={sponsor.documentId} value={sponsor.documentId}>
                     {sponsor.name}
@@ -189,7 +190,7 @@ export default function SponsorEditor({ sponsorships, onChange }: Props) {
                 }}
               >
                 <i className="bx bx-plus" />
-                New
+                {t("new")}
               </button>
             </div>
           </div>
@@ -202,7 +203,7 @@ export default function SponsorEditor({ sponsorships, onChange }: Props) {
               <input
                 type="text"
                 className="admin-input admin-input-sm"
-                placeholder="Enter category name..."
+                placeholder={t("enterCategoryName")}
                 value={customCategoryName}
                 onChange={(e) => setCustomCategoryName(e.target.value)}
                 onKeyDown={(e) => {
@@ -228,7 +229,7 @@ export default function SponsorEditor({ sponsorships, onChange }: Props) {
                 }}
                 disabled={!customCategoryName.trim()}
               >
-                Add
+                {t("add")}
               </button>
               <button
                 type="button"
@@ -238,7 +239,7 @@ export default function SponsorEditor({ sponsorships, onChange }: Props) {
                   setShowCustomCategoryInput(false)
                 }}
               >
-                Cancel
+                {t("cancel")}
               </button>
             </div>
           ) : (
@@ -253,7 +254,7 @@ export default function SponsorEditor({ sponsorships, onChange }: Props) {
                 }
               }}
             >
-              <option value="">Add category...</option>
+              <option value="">{t("addCategory")}</option>
               {DEFAULT_CATEGORIES.filter(
                 (cat) => !sponsorships.some((s) => s.category === cat)
               ).map((cat) => (
@@ -261,7 +262,7 @@ export default function SponsorEditor({ sponsorships, onChange }: Props) {
                   {cat}
                 </option>
               ))}
-              <option value="__custom">Custom category...</option>
+              <option value="__custom">{t("customCategory")}</option>
             </select>
           )}
         </div>
@@ -270,11 +271,19 @@ export default function SponsorEditor({ sponsorships, onChange }: Props) {
       {/* Create Sponsor Modal */}
       {showCreateModal && (
         <CreateSponsorModal
+          existingSponsors={availableSponsors}
           onClose={() => {
             setShowCreateModal(false)
             setCreateForCategory(null)
           }}
           onCreate={handleCreateSponsor}
+          onUseExisting={(sponsor) => {
+            if (createForCategory) {
+              addSponsorToCategory(createForCategory, sponsor)
+            }
+            setShowCreateModal(false)
+            setCreateForCategory(null)
+          }}
         />
       )}
     </div>
@@ -283,12 +292,19 @@ export default function SponsorEditor({ sponsorships, onChange }: Props) {
 
 // Create Sponsor Modal Component
 interface CreateSponsorModalProps {
+  existingSponsors: Sponsor[]
   onClose: () => void
   onCreate: (name: string, url: string) => Promise<Sponsor | null>
+  onUseExisting: (sponsor: Sponsor) => void
 }
 
-function CreateSponsorModal({ onClose, onCreate }: CreateSponsorModalProps) {
-  const t = useTranslations("adminCrud")
+function CreateSponsorModal({
+  existingSponsors,
+  onClose,
+  onCreate,
+  onUseExisting,
+}: CreateSponsorModalProps) {
+  const t = useTranslations("adminEvents.sponsorEditor")
   const [name, setName] = useState("")
   const [url, setUrl] = useState("")
   const [isCreating, setIsCreating] = useState(false)
@@ -300,12 +316,18 @@ function CreateSponsorModal({ onClose, onCreate }: CreateSponsorModalProps) {
     return () => setMounted(false)
   }, [])
 
+  // A sponsor list is global: creating a duplicate name is rejected by the API,
+  // so surface the existing one instead of letting the user hit that dead end.
+  const duplicate = existingSponsors.find(
+    (s) => s.name.trim().toLowerCase() === name.trim().toLowerCase()
+  )
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     e.stopPropagation()
 
     if (!name.trim()) {
-      setError("Name is required")
+      setError(t("nameRequiredError"))
       return
     }
 
@@ -314,7 +336,7 @@ function CreateSponsorModal({ onClose, onCreate }: CreateSponsorModalProps) {
 
     const result = await onCreate(name.trim(), url.trim())
     if (!result) {
-      setError("Failed to create sponsor")
+      setError(t("failedToCreate"))
     }
 
     setIsCreating(false)
@@ -324,7 +346,7 @@ function CreateSponsorModal({ onClose, onCreate }: CreateSponsorModalProps) {
     <div className="admin-modal-overlay" onClick={onClose}>
       <div className="admin-modal sponsor-modal" onClick={(e) => e.stopPropagation()}>
         <div className="admin-modal-header">
-          <h3>{t("adminCrud.sponsors.create.title")}</h3>
+          <h3>{t("createNewSponsor")}</h3>
           <button type="button" className="admin-modal-close" onClick={onClose}>
             <i className="bx bx-x" />
           </button>
@@ -338,20 +360,34 @@ function CreateSponsorModal({ onClose, onCreate }: CreateSponsorModalProps) {
             </div>
           )}
 
+          {duplicate && (
+            <div className="admin-alert admin-alert-warning admin-alert-sm">
+              <i className="bx bx-info-circle" />
+              <span>{t("duplicateHint", { name: duplicate.name })}</span>
+              <button
+                type="button"
+                className="admin-btn admin-btn-secondary admin-btn-sm"
+                onClick={() => onUseExisting(duplicate)}
+              >
+                {t("useExisting")}
+              </button>
+            </div>
+          )}
+
           <div className="admin-form-group">
-            <label htmlFor="sponsorName">{t("adminCrud.sponsors.form.nameLabel")}</label>
+            <label htmlFor="sponsorName">{t("nameRequired")}</label>
             <input
               type="text"
               id="sponsorName"
               value={name}
               onChange={(e) => setName(e.target.value)}
               className="admin-input"
-              placeholder={t("adminCrud.sponsors.form.namePlaceholder")}
+              placeholder={t("sponsorNamePlaceholder")}
             />
           </div>
 
           <div className="admin-form-group">
-            <label htmlFor="sponsorUrl">Website URL</label>
+            <label htmlFor="sponsorUrl">{t("websiteUrl")}</label>
             <input
               type="url"
               id="sponsorUrl"
@@ -370,23 +406,23 @@ function CreateSponsorModal({ onClose, onCreate }: CreateSponsorModalProps) {
             onClick={onClose}
             disabled={isCreating}
           >
-            Cancel
+            {t("cancel")}
           </button>
           <button
             type="button"
             className="admin-btn admin-btn-primary"
             onClick={handleSubmit}
-            disabled={isCreating || !name.trim()}
+            disabled={isCreating || !name.trim() || Boolean(duplicate)}
           >
             {isCreating ? (
               <>
                 <i className="bx bx-loader-alt bx-spin" />
-                {t("adminCrud.common.creating")}...
+                {t("creating")}
               </>
             ) : (
               <>
                 <i className="bx bx-plus" />
-                {t("adminCrud.sponsors.create.submitButton")}
+                {t("createSponsor")}
               </>
             )}
           </button>

--- a/packages/web/src/styles/admin/_forms.scss
+++ b/packages/web/src/styles/admin/_forms.scss
@@ -724,6 +724,30 @@ label.admin-btn {
   color: #16a34a;
 }
 
+.admin-alert-warning {
+  background-color: rgba(217, 119, 6, 0.1);
+  border: 1px solid rgba(217, 119, 6, 0.2);
+  color: #b45309;
+
+  span {
+    flex: 1;
+  }
+
+  .admin-btn {
+    flex-shrink: 0;
+  }
+}
+
+.admin-alert-sm {
+  padding: 10px 14px;
+  font-size: 13px;
+  margin-bottom: 12px;
+
+  i {
+    font-size: 16px;
+  }
+}
+
 // ===========================================
 // Page Header
 // ===========================================


### PR DESCRIPTION
Reported by Manolo Lopez: adding **KairosDS** as a Gold sponsor on his event was impossible — the create dialog rendered raw translation keys and then failed with *"A sponsor with this name already exists"*, with no way forward.

Three separate problems stacked up.

### 1. Raw i18n keys in the sponsor dialog

`sponsor-editor.tsx` called `useTranslations("adminCrud")` and then `t("adminCrud.sponsors.create.title")` — double-prefixed, so next-intl fell back to printing the key path. A complete `adminEvents.sponsorEditor` block already existed in all six locale files but was never wired up. The same double prefix affected 14 keys in the location create form.

The rest of the editor was hardcoded English regardless of locale ("Add sponsor...", "New", "Add category...", "Website URL", "Cancel", ...).

### 2. Sponsor dropdown silently truncated

`getAvailableSponsors` requested `pagination[pageSize]=1000`, but `packages/api/config/api.ts` sets `maxLimit: 100`. Production has 140 sponsors sorted `name:asc`, so everything after the 100th was invisible in the picker — which is exactly what pushes editors towards the "New" button. Now pages through the full list.

### 3. Duplicate name was a dead end

Sponsor `name` is `unique`, so creating one that already exists is rejected by the API and the modal just showed a red banner. Typing a name that matches an existing sponsor now surfaces that sponsor with a **use the existing one** button that adds it straight to the category, and disables create.

### Also

- Added the `.admin-alert-warning` variant and promoted `.admin-alert-sm` out of the Stripe-only scope — the sponsor editor already used that class with no effect.
- 4 new keys × 6 locales (`removeCategory`, `nameRequiredError`, `duplicateHint`, `useExisting`), informal register, matching the existing glossary.

### Verification

- `bun run --filter play14-web typecheck` — clean
- `bun run --filter play14-web test` — 288 tests pass
- i18n diff — 2037 keys, all six locales, zero drift
- Biome clean

### Follow-up, not in this PR

Production has two records for the same company: `Kairos` (has logo + `kairosds.com`) and `KairosDS` (empty, left over from an earlier attempt that created the sponsor but never attached it). Needs a manual merge — no data changes here.